### PR TITLE
Spark connect refactor context

### DIFF
--- a/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeAppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeAppServlet.java
@@ -63,7 +63,7 @@ public abstract class AtlassianIframeAppServlet extends AtlassianAppServlet {
      */
     private void prepareIframeContentIndex(Document document) throws IOException {
         // load contentWindow part of the iFrameResizer (inject as inline script), otherwise left the app untouched
-        String iframeResizerContentWindowJs = DocumentOutputUtil.getIframeResizeContentWindowJs();
+        String iframeResizerContentWindowJs = DocumentOutputUtil.getIframeContentWindowJs();
         document.head().append("\n<script>\n" + iframeResizerContentWindowJs + "\n</script>\n");
     }
 
@@ -113,7 +113,7 @@ public abstract class AtlassianIframeAppServlet extends AtlassianAppServlet {
                 DocumentOutputUtil.getIframeAdminContentWrapperTemplate(),
                 DocumentOutputUtil.generateAdminIframeTemplateContext(
                         props.getRequest().getRequestURI(), "spark_admin_iframe",
-                        "admin", null, props.getRequest().getQueryString()));
+                        "admin", props.getRequest().getQueryString()));
 
         document.body().append(iframeHtml);
     }

--- a/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
@@ -16,9 +16,7 @@ public class DocumentOutputUtil {
 
     private static final String IFRAME_RESIZE_JS_PATH = "com/k15t/spark/iframeResizer.min.js";
 
-    // TODO rename methods to not reference iframe_resize directly but something like
-    // content window deps...
-    private static final String IFRAME_RESIZE_CONTENT_WINDOW_JS_PATH = "com/k15t/spark/spark-dist.contentWindow.js";
+    private static final String IFRAME_CONTENT_WINDOW_JS_PATH = "com/k15t/spark/spark-dist.contentWindow.js";
 
     private static final String IFRAME_CONTENT_WRAPPER_TEMPLATE_PATH = "com/k15t/spark/content_iframe_wrapper.vm";
 
@@ -44,17 +42,22 @@ public class DocumentOutputUtil {
 
 
     /**
-     * Returns the contents of the iframe contentWindow side part of the iframeResizer JS library.
-     * The result can be injected into a loaded iframe as an script element containing the library
-     * as inline JS.
+     * <p>
+     * Returns JS code that should be injected into a document that is loaded into a SPARK controlled
+     * iframe
+     * </p><p>
+     * Includes contents of the iframe contentWindow side part of the iframeResizer JS library as well
+     * as some SPARK specific functions that make iframe's context available to the code embedded
+     * in the iframe
+     * </p>
      *
-     * @return iframeResizer.ContentWindow JS file as a string
+     * @return JS file to be included in SPARK iframe content document as a string
      * @throws NullPointerException if the resource cannot be found
      */
-    public static String getIframeResizeContentWindowJs() throws IOException {
+    public static String getIframeContentWindowJs() throws IOException {
         try (InputStream iframeResizeContentWindowFile =
                      DocumentOutputUtil.class.getClassLoader().
-                             getResourceAsStream(IFRAME_RESIZE_CONTENT_WINDOW_JS_PATH)) {
+                             getResourceAsStream(IFRAME_CONTENT_WINDOW_JS_PATH)) {
             return IOUtils.toString(iframeResizeContentWindowFile, "UTF-8");
         }
     }
@@ -86,7 +89,7 @@ public class DocumentOutputUtil {
      * Also custom context information can be injected into the app loaded in the iframe using velocity context.
      * </p><p>
      * The Velocity context used when rendering the template should be fetched by using
-     * {@link #generateAdminIframeTemplateContext(String, String, String, String, String) generateAdminIframeTemplateContext()}
+     * {@link #generateAdminIframeTemplateContext(String, String, String, String) generateAdminIframeTemplateContext()}
      * </p>
      *
      * @return iframe-content-wrapper Velocity template as a string
@@ -112,26 +115,17 @@ public class DocumentOutputUtil {
      * It is also possible to pass an information string to the content window of the iframe by using the
      * argument 'iframeContextInfo' (it will be available at SPARK.iframeContext). The contents will
      * be added as a JS string, but that string can contain eg. JSON info that the iframe JS code can parse.
-     * </p><p>
-     * It is also possible to specify an init-callback method that will be called once the SPARK
-     * initialization has run and the context info has been added to the iframe's contextWindow. The
-     * method can be specified using 'initCallbackFunctionName' and a function with that name has to
-     * be added into the SPARK namespace (in the iframe's context). The iframe JavaScript code should
-     * first check if the iframeContext info (in SPARK namespace) is already available, and if it is not,
-     * it should add the callback method to the SPARK namespace. Order of execution is not guaranteed.
      * </p>
      *
      * @param appBaseUrl base url for the SPA (must already contain trailing '/')
      * @param iframeIdToUse id to use for the iframe element
      * @param iframeContextInfo string to be added to the loaded iframe's window as 'SPARK.iframeContext'
-     * @param initCallbackFunctionName a name of the function to be called once SPARK init is done, null for no callback
      * @param queryString queryString to add to the url of the iframe content source (in addition to iframe_content parameter)
      * @return velocity context ready to be used with the iframe-admin-wrapper velocity template
      */
     public static Map<String, Object> generateAdminIframeTemplateContext(
             String appBaseUrl, String iframeIdToUse,
-            String iframeContextInfo, String initCallbackFunctionName,
-            String queryString) throws IOException {
+            String iframeContextInfo, String queryString) throws IOException {
         // add (possibly one more) layer of "-escaping so that the string can be added to js variable with "" delimiters
         String escapedIframeContext = iframeContextInfo == null ? "null" :
                 iframeContextInfo.replace("\"", "\\\"");
@@ -149,11 +143,6 @@ public class DocumentOutputUtil {
 
         String iframeSource = appBaseUrl + queryStringToUse;
 
-        // no need to allow all possible js variable names, just a reasonable and safe subset
-        if (initCallbackFunctionName != null && !initCallbackFunctionName.matches("^[a-zA-Z_$][0-9a-zA-Z_$]*$")) {
-            initCallbackFunctionName = null;
-        }
-
         String iframeResizerJs = getIframeResizeJs();
 
         HashMap<String, Object> context = new HashMap<String, Object>();
@@ -162,7 +151,6 @@ public class DocumentOutputUtil {
         context.put("iframeId", iframeIdToUse);
         context.put("iframeSrc", iframeSource);
         context.put("escapedIframeContext", escapedIframeContext);
-        context.put("iframeInitCallback", initCallbackFunctionName);
 
         return context;
     }

--- a/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
@@ -113,13 +113,13 @@ public class DocumentOutputUtil {
      * parameter that is needed by the SPARK framework.
      * </p><p>
      * It is also possible to pass an information string to the content window of the iframe by using the
-     * argument 'iframeContextInfo' (it will be available at SPARK.iframeContext). The contents will
+     * argument 'iframeContextInfo' (it will be available using SPARK.getContextData()). The contents will
      * be added as a JS string, but that string can contain eg. JSON info that the iframe JS code can parse.
      * </p>
      *
      * @param appBaseUrl base url for the SPA (must already contain trailing '/')
      * @param iframeIdToUse id to use for the iframe element
-     * @param iframeContextInfo string to be added to the loaded iframe's window as 'SPARK.iframeContext'
+     * @param iframeContextInfo string that will be available in the iframe's context using SPARK.getContextData()
      * @param queryString queryString to add to the url of the iframe content source (in addition to iframe_content parameter)
      * @return velocity context ready to be used with the iframe-admin-wrapper velocity template
      */

--- a/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/util/DocumentOutputUtil.java
@@ -15,7 +15,10 @@ import java.util.Map;
 public class DocumentOutputUtil {
 
     private static final String IFRAME_RESIZE_JS_PATH = "com/k15t/spark/iframeResizer.min.js";
-    private static final String IFRAME_RESIZE_CONTENT_WINDOW_JS_PATH = "com/k15t/spark/iframeResizer.contentWindow.min.js";
+
+    // TODO rename methods to not reference iframe_resize directly but something like
+    // content window deps...
+    private static final String IFRAME_RESIZE_CONTENT_WINDOW_JS_PATH = "com/k15t/spark/spark-dist.contentWindow.js";
 
     private static final String IFRAME_CONTENT_WRAPPER_TEMPLATE_PATH = "com/k15t/spark/content_iframe_wrapper.vm";
 

--- a/spark-common/src/main/js/gulpfile.js
+++ b/spark-common/src/main/js/gulpfile.js
@@ -82,11 +82,22 @@ gulp.task('build', ['test', 'compile-css-to-js'], function() {
 
 });
 
+gulp.task('build-cont-win', function() {
+
+    return gulp.src([
+        'node_modules/iframe-resizer/js/iframeResizer.contentWindow.js',
+        'src_contentwin/spark-contentwindow.js'
+    ])
+        .pipe(concat('spark-dist.contentWindow.js'))
+        .pipe(gulp.dest('target/gen'));
+
+});
+
 gulp.task('clean-dist', function(done) {
     del('target/dist').then(done());
 });
 
-gulp.task('dist', ['clean-dist', 'build'], function() {
+gulp.task('dist', ['clean-dist', 'build', 'build-cont-win'], function() {
 
     return gulp.src(['target/gen/*.js', 'src/*',
         'node_modules/iframe-resizer/js/iframeResizer.js',

--- a/spark-common/src/main/js/src/spark-bootstrap.js
+++ b/spark-common/src/main/js/src/spark-bootstrap.js
@@ -250,17 +250,17 @@ AJS.toInit(function($) {
          *
          * A JS-object containing controls for interacting with the parent window (eg. closing
          * the iframe dialog) will be added into the global scope of the app loaded into
-         * the iframe to path SPARK.iframeControls (this works as the app in the iframe will
+         * the iframe to path SPARK.dialogControls (this works as the app in the iframe will
          * be loaded from the same origin as the parent app).
          *
-         * The SPARK.iframeControls will contain method for closing the dialog 'closeDialog',
+         * The SPARK.dialogControls will contain method for closing the dialog 'closeDialog',
          * and 'dialogChrome' object for controlling possible dialog toolbar. If there is
          * no toolbar 'dialogChrome' is null, otherwise it will contain references to the buttons
          * in the dialog chrome ('cancelBtn' and 'confirmBtn').
          *
          * It is possible to pass custom extra data to the context of the loaded iframe
          * by setting an object to dialogOptions.contextData . A reference to this object
-         * will be added to SPARK.iframeControls.contextData in the iframe's context.
+         * will be added to SPARK.dialogControls.contextData in the iframe's context.
          *
          * @param appName name of the app (used as prefix for eg. element ids)
          * @param appPath relative path from which the iframe content is to be loaded
@@ -336,7 +336,7 @@ AJS.toInit(function($) {
             var iwSpark = {};
             iframeDomEl.SPARK = iwSpark;
 
-            iwSpark.iframeControls = {
+            iwSpark.dialogControls = {
                 'closeDialog': iframeCloser,
                 'dialogChrome': dialogChrome
             };

--- a/spark-common/src/main/js/src/spark-bootstrap.js
+++ b/spark-common/src/main/js/src/spark-bootstrap.js
@@ -326,19 +326,6 @@ AJS.toInit(function($) {
                 }
             };
 
-            // add needed extras to the loaded iframe
-
-            var iframeElement = iframeWrapperElement.find('iframe');
-            var iframeDomEl = iframeElement.get()[0];
-
-            var iframeCloser = function() {
-                bodyEl.removeClass('spark-no-scroll');
-                if (iframeDomEl.iFrameResizer) {
-                    iframeDomEl.iFrameResizer.close();
-                }
-                iframeWrapperElement.remove();
-            };
-
             // access the DOM of the js app loaded into the iframe and push
             // an object into that context giving a simple way for the loaded
             // app to eg. tell the parent window to close the dialog (and the iframe)

--- a/spark-common/src/main/js/src/spark-bootstrap.js
+++ b/spark-common/src/main/js/src/spark-bootstrap.js
@@ -259,8 +259,8 @@ AJS.toInit(function($) {
          * in the dialog chrome ('cancelBtn' and 'confirmBtn').
          *
          * It is possible to pass custom extra data to the context of the loaded iframe
-         * by setting an object to dialogOptions.extraData . A reference to this object
-         * will be added to SPARK.iframeControls.extraData in the iframe's context.
+         * by setting an object to dialogOptions.contextData . A reference to this object
+         * will be added to SPARK.iframeControls.contextData in the iframe's context.
          *
          * @param appName name of the app (used as prefix for eg. element ids)
          * @param appPath relative path from which the iframe content is to be loaded
@@ -341,7 +341,7 @@ AJS.toInit(function($) {
                 'dialogChrome': dialogChrome
             };
 
-            iwSpark.extraData = dialogSettings.extraData;
+            iwSpark.contextData = dialogSettings.contextData;
 
             if (iframeElement.iFrameResize) {
                 iframeElement.iFrameResize([{

--- a/spark-common/src/main/js/src/spark-bootstrap.js
+++ b/spark-common/src/main/js/src/spark-bootstrap.js
@@ -270,6 +270,9 @@ AJS.toInit(function($) {
 
             var bodyEl = $('body');
 
+            // to remove scrollers from content below the iframe dialog
+            bodyEl.addClass('spark-no-scroll');
+
             var fullAppPath = AJS.contextPath() + appPath;
 
             var elementIdSparkAppContainer = appName + '-spark-app-container';
@@ -295,26 +298,6 @@ AJS.toInit(function($) {
                 'src': location.protocol + '//' + location.host + fullAppPath + iframeSrcQuery,
                 'createOptions': dialogSettings
             }));
-            iframeWrapperElement.appendTo(bodyEl);
-
-            // add needed extras to the loaded iframe
-
-            var iframeElement = iframeWrapperElement.find('iframe');
-            var iframeDomEl = iframeElement.get()[0];
-
-            // to remove scrollers from content below the iframe dialog
-            bodyEl.addClass('spark-no-scroll');
-
-            var iframeCloser = function(resultData) {
-                bodyEl.removeClass('spark-no-scroll');
-                if (iframeDomEl.iFrameResizer) {
-                    iframeDomEl.iFrameResizer.close();
-                }
-                iframeWrapperElement.remove();
-                if (dialogSettings.onClose) {
-                    dialogSettings.onClose(resultData);
-                }
-            };
 
             // add an easy way for the contained iframe to access the dialog chrome (if added)
             var dialogChrome = null;
@@ -327,35 +310,60 @@ AJS.toInit(function($) {
                 };
             }
 
-            iframeElement.ready(function() {
+            // add needed extras to the loaded iframe
 
-                // access the DOM of the js app loaded into the iframe and push
-                // an object into that context giving a simple way for the loaded
-                // app to eg. tell the parent window to close the dialog (and the iframe)
+            var iframeElement = iframeWrapperElement.find('iframe');
+            var iframeDomEl = iframeElement.get()[0];
 
-                // should work as long as the parent and the app in the iframe share
-                // the same origin (which should be true for all SPARK apps)
-
-                var iw = iframeDomEl.contentWindow ? iframeDomEl.contentWindow :
-                    iframeDomEl.contentDocument.defaultView;
-
-                if (!iw.SPARK) {
-                    iw.SPARK = {};
+            var iframeCloser = function(resultData) {
+                bodyEl.removeClass('spark-no-scroll');
+                if (iframeDomEl.iFrameResizer) {
+                    iframeDomEl.iFrameResizer.close();
                 }
-                iw.SPARK.iframeControls = {
-                    'closeDialog': iframeCloser,
-                    'dialogChrome': dialogChrome,
-                    'extraData': dialogSettings.extraData
-                };
-
-                if (iframeElement.iFrameResize) {
-                    iframeElement.iFrameResize([{
-                        'autoResize': true,
-                        'heightCalculationMethod': 'max'
-                    }]);
+                iframeWrapperElement.remove();
+                if (dialogSettings.onClose) {
+                    dialogSettings.onClose(resultData);
                 }
+            };
 
-            });
+            // add needed extras to the loaded iframe
+
+            var iframeElement = iframeWrapperElement.find('iframe');
+            var iframeDomEl = iframeElement.get()[0];
+
+            var iframeCloser = function() {
+                bodyEl.removeClass('spark-no-scroll');
+                if (iframeDomEl.iFrameResizer) {
+                    iframeDomEl.iFrameResizer.close();
+                }
+                iframeWrapperElement.remove();
+            };
+
+            // access the DOM of the js app loaded into the iframe and push
+            // an object into that context giving a simple way for the loaded
+            // app to eg. tell the parent window to close the dialog (and the iframe)
+
+            // should work as long as the parent and the app in the iframe share
+            // the same origin (which should be true for all SPARK apps)
+
+            var iwSpark = {};
+            iframeDomEl.SPARK = iwSpark;
+
+            iwSpark.iframeControls = {
+                'closeDialog': iframeCloser,
+                'dialogChrome': dialogChrome
+            };
+
+            iwSpark.extraData = dialogSettings.extraData;
+
+            if (iframeElement.iFrameResize) {
+                iframeElement.iFrameResize([{
+                    'autoResize': true,
+                    'heightCalculationMethod': 'max'
+                }]);
+            }
+
+            iframeWrapperElement.appendTo(bodyEl);
 
             return elementIdSparkAppContainer;
 

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -6,8 +6,8 @@ var SPARK = SPARK || {};
     // same domain is prereq for SPARK usage
     var parentSpark = windowEl.frameElement.SPARK;
 
-    var getData = function() {
-        return parentSpark.extraData;
+    var getContextData = function() {
+        return parentSpark.contextData;
     };
 
     var getDialogControls = function() {
@@ -15,7 +15,7 @@ var SPARK = SPARK || {};
         return parentSpark.iframeControls;
     };
 
-    sparkInstance.getData = getData;
+    sparkInstance.getContextData = getContextData;
     sparkInstance.getDialogControls = getDialogControls;
 
 })(SPARK, window);

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -19,9 +19,7 @@ var SPARK = SPARK || {};
 
     };
 
-    SPARK = {
-        getData: getData,
-        getDialogControls: getDialogControls
-    };
+    sparkInstance.getData = getData;
+    sparkInstance.getDialogControls = getDialogControls;
 
 })(SPARK, window);

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -1,0 +1,27 @@
+var SPARK = SPARK || {};
+
+(function(sparkInstance, windowEl) {
+
+    // windowEl.frameElement would be null if domains are not same but
+    // same domain is prereq for SPARK usage
+    var parentSpark = windowEl.frameElement.SPARK;
+
+    var getData = function() {
+
+        return parentSpark.extraData;
+
+    };
+
+    var getDialogControls = function() {
+
+        // TODO rename iframeControls to dialogControls..?
+        return parentSpark.iframeControls;
+
+    };
+
+    SPARK = {
+        getData: getData,
+        getDialogControls: getDialogControls
+    };
+
+})(SPARK, window);

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -11,8 +11,8 @@ var SPARK = SPARK || {};
     };
 
     var getDialogControls = function() {
-        // TODO rename iframeControls to dialogControls..?
-        return parentSpark.iframeControls;
+        // TODO rename dialogControls to dialogControls..?
+        return parentSpark.dialogControls;
     };
 
     sparkInstance.getContextData = getContextData;

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -11,7 +11,6 @@ var SPARK = SPARK || {};
     };
 
     var getDialogControls = function() {
-        // TODO rename dialogControls to dialogControls..?
         return parentSpark.dialogControls;
     };
 

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -7,16 +7,12 @@ var SPARK = SPARK || {};
     var parentSpark = windowEl.frameElement.SPARK;
 
     var getData = function() {
-
         return parentSpark.extraData;
-
     };
 
     var getDialogControls = function() {
-
         // TODO rename iframeControls to dialogControls..?
         return parentSpark.iframeControls;
-
     };
 
     sparkInstance.getData = getData;

--- a/spark-common/src/main/js/test/mocks/spark-dep-mocks.js
+++ b/spark-common/src/main/js/test/mocks/spark-dep-mocks.js
@@ -66,7 +66,7 @@ SPARK.Common.Templates = SPARK.Common.Templates || {};
 (function() {
 
     SPARK.Common.Templates.appFullscreenContaineriFrame = function() {
-        return '<div class="spark-mock-template"></div>';
+        return '<div class="spark-mock-template"><iframe></iframe></div>';
     };
 
 })();

--- a/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
+++ b/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
@@ -139,18 +139,6 @@ describe('iframeAppLoader', function() {
 
         });
 
-        it('adds a callback to be called once the iframe is loaded', function() {
-
-            this.iframeOpener('test-app-name', '/test/app/path');
-
-            expect(this.$ready).toHaveBeenCalled();
-
-            expect(this.$ready).toHaveBeenCalledTimes(1);
-
-            expect(this.$ready).toHaveBeenCalledWith(jasmine.any(Function));
-
-        });
-
         describe('Iframe context handling', function() {
 
             beforeEach(function() {
@@ -274,18 +262,22 @@ describe('iframeAppLoader', function() {
             it('close-method invokes the onClose handler with result data', function() {
                 var closeCallback = jasmine.createSpy('dialogCloseCallback');
                 this.iframeOpener('test-app-name', '/test/app/path', { onClose: closeCallback });
+
+                var iframeSpark = this.getSparkIframeContext();
+
                 var iframeResizer = jasmine.createSpyObj('iFrameResizer', ['close']);
                 var iframeDomEl = $('body').find('iframe').get()[0];
                 expect(iframeDomEl).toBeDefined();
                 iframeDomEl.iFrameResizer = iframeResizer;
-                this.runReadyCb();
 
                 expect(iframeResizer.close).not.toHaveBeenCalled();
-                var iw = this.getIframeContentWindow();
 
-                var resultData = { a: 'b', c: function () {}};
+                var resultData = {
+                    a: 'b', c: function() {
+                    }
+                };
 
-                iw.SPARK.iframeControls.closeDialog(resultData);
+                iframeSpark.iframeControls.closeDialog(resultData);
 
                 expect(closeCallback).toHaveBeenCalledTimes(1);
                 expect(closeCallback).toHaveBeenCalledWith(resultData);

--- a/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
+++ b/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
@@ -214,14 +214,14 @@ describe('iframeAppLoader', function() {
                 expect(iframeDomEl.SPARK.iframeControls.closeDialog).toEqual(jasmine.any(Function));
 
                 // check in the case that there is nothing unexpected in the iframe context
-                // - just the close method (dialogChrome is null by default, and the extraData
+                // - just the close method (dialogChrome is null by default, and the contextData
                 // what it was in dialog options, ending up undefined when not specified)
                 expect(iframeDomEl.SPARK.iframeControls).toEqual({
                     'closeDialog': jasmine.any(Function),
                     'dialogChrome': null
                 });
 
-                expect(iframeDomEl.SPARK.extraData).not.toBeDefined();
+                expect(iframeDomEl.SPARK.contextData).not.toBeDefined();
 
             });
 
@@ -285,22 +285,22 @@ describe('iframeAppLoader', function() {
 
             it('passes extra context data to iframe context', function() {
 
-                var extraData = {
+                var contextData = {
                     'some': 'random',
                     'extra': ['data', 'for', 'iframe']
                 };
 
                 this.iframeOpener('test-app-name', '/test/app/path', {
-                    'extraData': extraData
+                    'contextData': contextData
                 });
 
                 var iframeSpark = this.getSparkIframeContext();
 
                 expect(iframeSpark.iframeControls).toEqual(jasmine.any(Object));
 
-                expect(iframeSpark.extraData).toEqual(jasmine.any(Object));
+                expect(iframeSpark.contextData).toEqual(jasmine.any(Object));
 
-                expect(iframeSpark.extraData).toEqual({
+                expect(iframeSpark.contextData).toEqual({
                     'some': 'random',
                     'extra': ['data', 'for', 'iframe']
                 });
@@ -435,7 +435,7 @@ describe('iframeAppLoader', function() {
 
                     this.iframeOpener(this.appNameToUse, '/path/to/app/', {
                         'addChrome': true,
-                        'extraData': { 'test': 'some extra', 'with': { 'chrome': true } }
+                        'contextData': { 'test': 'some extra', 'with': { 'chrome': true } }
                     });
 
                     // chrome added
@@ -459,7 +459,7 @@ describe('iframeAppLoader', function() {
                             'confirmBtn': jasmine.any(HTMLElement)
                         }
                     });
-                    expect(iframeSparkCont.extraData).toEqual({
+                    expect(iframeSparkCont.contextData).toEqual({
                         'test': 'some extra',
                         'with': { 'chrome': true }
                     });

--- a/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
+++ b/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
@@ -209,14 +209,14 @@ describe('iframeAppLoader', function() {
                 // should have no added the SPARK context
                 expect(iframeDomEl.SPARK).toBeDefined();
 
-                expect(iframeDomEl.SPARK.iframeControls).toEqual(jasmine.any(Object));
+                expect(iframeDomEl.SPARK.dialogControls).toEqual(jasmine.any(Object));
 
-                expect(iframeDomEl.SPARK.iframeControls.closeDialog).toEqual(jasmine.any(Function));
+                expect(iframeDomEl.SPARK.dialogControls.closeDialog).toEqual(jasmine.any(Function));
 
                 // check in the case that there is nothing unexpected in the iframe context
                 // - just the close method (dialogChrome is null by default, and the contextData
                 // what it was in dialog options, ending up undefined when not specified)
-                expect(iframeDomEl.SPARK.iframeControls).toEqual({
+                expect(iframeDomEl.SPARK.dialogControls).toEqual({
                     'closeDialog': jasmine.any(Function),
                     'dialogChrome': null
                 });
@@ -233,7 +233,7 @@ describe('iframeAppLoader', function() {
 
                 expect($('body').hasClass('spark-no-scroll')).toBeTruthy();
 
-                iframeSparkCont.iframeControls.closeDialog();
+                iframeSparkCont.dialogControls.closeDialog();
 
                 expect($('body').hasClass('spark-no-scroll')).toBeFalsy();
 
@@ -252,7 +252,7 @@ describe('iframeAppLoader', function() {
 
                 // call the close method, now the should iframe-dialog wrapper
                 // should not be there anymore
-                iframeSpark.iframeControls.closeDialog();
+                iframeSpark.dialogControls.closeDialog();
 
                 expect($('body').find('#iframe_test_el').length).toEqual(0);
                 expect($('body').find('iframe').length).toEqual(0);
@@ -277,7 +277,7 @@ describe('iframeAppLoader', function() {
                     }
                 };
 
-                iframeSpark.iframeControls.closeDialog(resultData);
+                iframeSpark.dialogControls.closeDialog(resultData);
 
                 expect(closeCallback).toHaveBeenCalledTimes(1);
                 expect(closeCallback).toHaveBeenCalledWith(resultData);
@@ -296,7 +296,7 @@ describe('iframeAppLoader', function() {
 
                 var iframeSpark = this.getSparkIframeContext();
 
-                expect(iframeSpark.iframeControls).toEqual(jasmine.any(Object));
+                expect(iframeSpark.dialogControls).toEqual(jasmine.any(Object));
 
                 expect(iframeSpark.contextData).toEqual(jasmine.any(Object));
 
@@ -337,7 +337,7 @@ describe('iframeAppLoader', function() {
                 expect(iframeResizer.close).not.toHaveBeenCalled();
 
                 var iframeSparkCont = this.getSparkIframeContext();
-                iframeSparkCont.iframeControls.closeDialog();
+                iframeSparkCont.dialogControls.closeDialog();
 
                 expect(iframeResizer.close).toHaveBeenCalledTimes(1);
 
@@ -380,7 +380,7 @@ describe('iframeAppLoader', function() {
 
                     var iframeSpark = this.getSparkIframeContext();
 
-                    expect(iframeSpark.iframeControls).toEqual({
+                    expect(iframeSpark.dialogControls).toEqual({
                         'closeDialog': jasmine.any(Function),
                         'dialogChrome': {
                             'cancelBtn': jasmine.any(HTMLElement),
@@ -396,8 +396,8 @@ describe('iframeAppLoader', function() {
                     expect(parentCancelEl).toBeDefined();
                     expect(parentSubmitEl).toBeDefined();
 
-                    expect(iframeSpark.iframeControls.dialogChrome.cancelBtn).toEqual(parentCancelEl);
-                    expect(iframeSpark.iframeControls.dialogChrome.confirmBtn).toEqual(parentSubmitEl);
+                    expect(iframeSpark.dialogControls.dialogChrome.cancelBtn).toEqual(parentCancelEl);
+                    expect(iframeSpark.dialogControls.dialogChrome.confirmBtn).toEqual(parentSubmitEl);
 
                 });
 
@@ -413,7 +413,7 @@ describe('iframeAppLoader', function() {
                         .find('#test-app-spark-app-container-chrome-submit').length).toEqual(1);
 
                     var iframeSparkCont = this.getSparkIframeContext();
-                    iframeSparkCont.iframeControls.closeDialog();
+                    iframeSparkCont.dialogControls.closeDialog();
 
                     expect($('body')
                         .find('#test-app-spark-app-container-chrome-cancel').length).toEqual(0);
@@ -452,7 +452,7 @@ describe('iframeAppLoader', function() {
 
                     // added expected data to iframe's contextwindow
                     expect(iframeSparkCont).toEqual(jasmine.any(Object));
-                    expect(iframeSparkCont.iframeControls).toEqual({
+                    expect(iframeSparkCont.dialogControls).toEqual({
                         'closeDialog': jasmine.any(Function),
                         'dialogChrome': {
                             'cancelBtn': jasmine.any(HTMLElement),
@@ -478,7 +478,7 @@ describe('iframeAppLoader', function() {
                     iframeDomEl.iFrameResizer = iframeDomElResizerObj;
 
                     // close dialog and check that everything is cleaned up
-                    iframeSparkCont.iframeControls.closeDialog();
+                    iframeSparkCont.dialogControls.closeDialog();
 
                     expect($('body')
                         .find('#test-app-spark-app-container-chrome-cancel').length).toEqual(0);

--- a/spark-common/src/main/resources/com/k15t/spark/content_iframe_wrapper.vm
+++ b/spark-common/src/main/resources/com/k15t/spark/content_iframe_wrapper.vm
@@ -11,7 +11,7 @@
         if (!iframeEl.SPARK) {
             iframeEl.SPARK = {};
         }
-        iframeEl.SPARK.extraData = "${escapedIframeContext}";
+        iframeEl.SPARK.contextData = "${escapedIframeContext}";
         iFrameResize({
             'autoResize': true,
             'heightCalculationMethod': 'max'

--- a/spark-common/src/main/resources/com/k15t/spark/content_iframe_wrapper.vm
+++ b/spark-common/src/main/resources/com/k15t/spark/content_iframe_wrapper.vm
@@ -7,21 +7,14 @@
 <iframe id="${iframeId}" scrolling="no" style="width: 100%; border: none;" src="${iframeSrc}"></iframe>
 <script>
     if (iFrameResize) {
+        var iframeEl = document.getElementById("${iframeId}");
+        if (!iframeEl.SPARK) {
+            iframeEl.SPARK = {};
+        }
+        iframeEl.SPARK.extraData = "${escapedIframeContext}";
         iFrameResize({
             'autoResize': true,
-            'heightCalculationMethod': 'max',
-            'initCallback': function(loadedIframe) {
-                var contentWin = loadedIframe.contentWindow;
-                if (!contentWin.SPARK) {
-                    contentWin.SPARK = {};
-                }
-                contentWin.SPARK.iframeContext = "${escapedIframeContext}";
-                #if($iframeInitCallback)
-                    if (contentWin.SPARK.${iframeInitCallback}) {
-                        contentWin.SPARK.${iframeInitCallback}();
-                    }
-                #end
-            }
+            'heightCalculationMethod': 'max'
         }, '#${iframeId}');
     }
 </script>

--- a/spark-common/src/test/java/com/k15t/spark/base/util/DocumentOutputUtilTest.java
+++ b/spark-common/src/test/java/com/k15t/spark/base/util/DocumentOutputUtilTest.java
@@ -26,7 +26,6 @@ public class DocumentOutputUtilTest {
     private static final String iframeSrcContextKey = "iframeSrc";
     private static final String iframeResizerJsContextKey = "iframeResizerJs";
     private static final String iframeInjContextVelocityKey = "escapedIframeContext";
-    private static final String iframeInitCallbackVelocityKey = "iframeInitCallback";
 
 
     @Test
@@ -36,8 +35,7 @@ public class DocumentOutputUtilTest {
 
         Map<String, Object> res =
                 DocumentOutputUtil.generateAdminIframeTemplateContext("/test/base/url/",
-                        "iframe-id", "{\"test-key\": \"test-value\"}",
-                        null, "");
+                        "iframe-id", "{\"test-key\": \"test-value\"}", "");
 
         Assert.assertEquals("iframe-id", res.get(iframeIdContextKey));
 
@@ -47,13 +45,10 @@ public class DocumentOutputUtilTest {
 
         Assert.assertEquals("{\\\"test-key\\\": \\\"test-value\\\"}", res.get(iframeInjContextVelocityKey));
 
-        Assert.assertEquals(null, res.get(iframeInitCallbackVelocityKey));
-
         // another try, main difference: invalid initCallback function name (should not be added to context)
 
         res = DocumentOutputUtil.generateAdminIframeTemplateContext("/test2/",
-                "id_of_second_iframe", "context information string '+!&",
-                "angular.initialized", "?space=32");
+                "id_of_second_iframe", "context information string '+!&", "?space=32");
 
         Assert.assertEquals("id_of_second_iframe", res.get(iframeIdContextKey));
 
@@ -63,13 +58,11 @@ public class DocumentOutputUtilTest {
 
         Assert.assertEquals("context information string '+!&", res.get(iframeInjContextVelocityKey));
 
-        Assert.assertEquals(null, res.get(iframeInitCallbackVelocityKey));
-
         // one more time, this time also the init callback should be added as expected
 
         res = DocumentOutputUtil.generateAdminIframeTemplateContext("/test/3/", "id3",
                 "{'context': {'pages': ['test1', 'test2'], 'result': {'success': false, 'code': 404}}}",
-                "sparkInitialized", "test_value=false&admin=true");
+                "test_value=false&admin=true");
 
         Assert.assertEquals("id3", res.get(iframeIdContextKey));
 
@@ -81,15 +74,13 @@ public class DocumentOutputUtilTest {
                 "{'context': {'pages': ['test1', 'test2'], 'result': {'success': false, 'code': 404}}}",
                 res.get(iframeInjContextVelocityKey));
 
-        Assert.assertEquals("sparkInitialized", res.get(iframeInitCallbackVelocityKey));
-
     }
 
 
     @Test
     public void getIframeContentWindowJs() throws IOException {
 
-        String iframeContWinJs = DocumentOutputUtil.getIframeResizeContentWindowJs();
+        String iframeContWinJs = DocumentOutputUtil.getIframeContentWindowJs();
 
         Assert.assertEquals("/* test placeholder of iframeResizer.contentWindow.min.js */", iframeContWinJs);
 
@@ -129,10 +120,10 @@ public class DocumentOutputUtilTest {
         String initScripElCont = initScriptEl.html();
 
         Map<String, Integer> refs = checkVelocityFragmentReferences(initScripElCont,
-                Arrays.asList(iframeInjContextVelocityKey, iframeInitCallbackVelocityKey, iframeIdContextKey), true);
+                Arrays.asList(iframeInjContextVelocityKey, iframeIdContextKey), true);
 
         Assert.assertTrue(refs.get(iframeInjContextVelocityKey) > 0);
-        //Assert.assertTrue(refs.get(iframeInitCallbackVelocityKey) > 0);
+
         // should call iFrameResize on the iframe with correct id
         Assert.assertTrue(refs.get(iframeIdContextKey) > 0);
 

--- a/spark-common/src/test/java/com/k15t/spark/base/util/DocumentOutputUtilTest.java
+++ b/spark-common/src/test/java/com/k15t/spark/base/util/DocumentOutputUtilTest.java
@@ -132,7 +132,7 @@ public class DocumentOutputUtilTest {
                 Arrays.asList(iframeInjContextVelocityKey, iframeInitCallbackVelocityKey, iframeIdContextKey), true);
 
         Assert.assertTrue(refs.get(iframeInjContextVelocityKey) > 0);
-        Assert.assertTrue(refs.get(iframeInitCallbackVelocityKey) > 0);
+        //Assert.assertTrue(refs.get(iframeInitCallbackVelocityKey) > 0);
         // should call iFrameResize on the iframe with correct id
         Assert.assertTrue(refs.get(iframeIdContextKey) > 0);
 

--- a/spark-common/src/test/resources/com/k15t/spark/spark-dist.contentWindow.js
+++ b/spark-common/src/test/resources/com/k15t/spark/spark-dist.contentWindow.js
@@ -1,0 +1,1 @@
+/* test placeholder of iframeResizer.contentWindow.min.js */

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSpaceAppAction.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSpaceAppAction.java
@@ -49,7 +49,7 @@ public abstract class ConfluenceIframeSpaceAppAction extends AbstractSpaceAction
 
     /**
      * <p>
-     * The result of this method will be injected into the context of the loaded iframe as SPARK.iframeContext
+     * The result of this method will be available in the context of the loaded iframe using SPARK.getContextData()
      * </p><p>
      * The JS variable will be a string. To pass structured information eg. JSON can be used.
      * </p><p>

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSpaceAppAction.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSpaceAppAction.java
@@ -36,7 +36,7 @@ public abstract class ConfluenceIframeSpaceAppAction extends AbstractSpaceAction
             String template = DocumentOutputUtil.getIframeAdminContentWrapperTemplate();
             Map<String, Object> context = DocumentOutputUtil.generateAdminIframeTemplateContext(
                     appBaseUrl, "spark_space_adm_iframe_" + idSuffix,
-                    getIframeContextInfo(), getIframeContextInitializedCallbackName(), getSpaQueryString());
+                    getIframeContextInfo(), getSpaQueryString());
 
             this.body = VelocityUtils.getRenderedContent(template, context);
         } catch (IOException e) {
@@ -63,29 +63,6 @@ public abstract class ConfluenceIframeSpaceAppAction extends AbstractSpaceAction
      */
     protected String getIframeContextInfo() {
         return "{\"space_key\": \"" + getSpaceKey() + "\"}";
-    }
-
-
-    /**
-     * <p>
-     * It is possible to specify a callback function name that will be called once the context information
-     * is injected into the iframe.
-     * </p><p>
-     * A function with the given name must be present in the SPARK object in the iframe's global context. If the
-     * function with given name (or SPARK) object is not present, nothing is called. This can happen also in
-     * normal operation because of initialization race conditions.
-     * </p><p>
-     * Correct way to use the init-callback method is to first check in the iframe's normal init-method to check
-     * whether the SPARK.iframeContext already is present, and if not, then add the SPARK object (if needed) and
-     * the init method with correct name to it.
-     * </p><p>
-     * Defaults to 'contextInitializedCallback'. If no initialization method is needed, null can be returned.
-     * </p>
-     *
-     * @return name of an initialization callback (on SPARK global object in iframe's context), or null if not needed
-     */
-    protected String getIframeContextInitializedCallbackName() {
-        return "contextInitializedCallback";
     }
 
 

--- a/spark-confluence/src/test/java/com/k15t/spark/confluence/ConfluenceSpaceAppActionTestCommon.java
+++ b/spark-confluence/src/test/java/com/k15t/spark/confluence/ConfluenceSpaceAppActionTestCommon.java
@@ -75,7 +75,7 @@ public class ConfluenceSpaceAppActionTestCommon {
         PowerMockito.mockStatic(DocumentOutputUtil.class);
 
         Mockito.when(DocumentOutputUtil.generateAdminIframeTemplateContext(anyString(), anyString(),
-                anyString(), anyString(), anyString())).thenReturn(velocityContextToReturn);
+                anyString(), anyString())).thenReturn(velocityContextToReturn);
 
         Mockito.when(DocumentOutputUtil.getIframeAdminContentWrapperTemplate()).thenReturn(velocityTemplateToReturn);
 

--- a/spark-confluence/src/test/java/com/k15t/spark/confluence/ConflunceIframeSpaceAppActionTest.java
+++ b/spark-confluence/src/test/java/com/k15t/spark/confluence/ConflunceIframeSpaceAppActionTest.java
@@ -82,7 +82,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 eq(requestContextPath + "/spark/space/testapp/baseurl/"), startsWith("spark_space_adm_iframe_"),
-                anyString(), anyString(), isNull(String.class));
+                anyString(), isNull(String.class));
 
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.getIframeAdminContentWrapperTemplate();
@@ -115,7 +115,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                eq("{\"space_key\": \"test-space-key\"}"), eq("contextInitializedCallback"), isNull(String.class));
+                eq("{\"space_key\": \"test-space-key\"}"), isNull(String.class));
 
 
         testSpaceKey = "KEY57";
@@ -128,7 +128,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                eq("{\"space_key\": \"KEY57\"}"), eq("contextInitializedCallback"), isNull(String.class));
+                eq("{\"space_key\": \"KEY57\"}"), isNull(String.class));
 
     }
 
@@ -146,7 +146,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                anyString(), anyString(), eq("?space_key=TEST&user=admin"));
+                anyString(), eq("?space_key=TEST&user=admin"));
 
 
         Mockito.when(servletRequest.getQueryString()).thenReturn("");
@@ -159,7 +159,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                anyString(), anyString(), eq(""));
+                anyString(), eq(""));
 
 
         Mockito.when(servletRequest.getQueryString()).thenReturn("test_param=value&other=42&third=75");
@@ -172,7 +172,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                anyString(), anyString(), eq("test_param=value&other=42&third=75"));
+                anyString(), eq("test_param=value&other=42&third=75"));
 
     }
 
@@ -200,7 +200,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 eq(requestContextPath + "/spark/space/testapp/baseurl/"), startsWith("spark_space_adm_iframe"),
-                anyString(), anyString(), eq("start_view=admin_v42"));
+                anyString(), eq("start_view=admin_v42"));
 
         // small sanity check that action was really completed as expected
         String genBody = instanceOverridingQuery.getBodyAsHtml();
@@ -219,11 +219,6 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
                 return "use_special_test_spa_type";
             }
 
-
-            @Override
-            protected String getIframeContextInitializedCallbackName() {
-                return "sparkInitReady";
-            }
         };
 
         String result = instanceOverridingIframeContext.index();
@@ -234,7 +229,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                eq("use_special_test_spa_type"), eq("sparkInitReady"), anyString());
+                eq("use_special_test_spa_type"), anyString());
 
         // small sanity check that action was really completed as expected
         String genBody = instanceOverridingIframeContext.getBodyAsHtml();
@@ -248,11 +243,6 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
                         "; start-view: space-admin;";
             }
 
-
-            @Override
-            protected String getIframeContextInitializedCallbackName() {
-                return "sparkInit2";
-            }
         };
         otherIframeContextOverrideTest.setSpace(spaceMock);
         Mockito.when(spaceMock.getKey()).thenReturn("key111");
@@ -266,8 +256,7 @@ public class ConflunceIframeSpaceAppActionTest extends ConfluenceSpaceAppActionT
         PowerMockito.verifyStatic(times(1));
         DocumentOutputUtil.generateAdminIframeTemplateContext(
                 anyString(), anyString(),
-                eq("space-key: key111; space-name: space name; start-view: space-admin;"),
-                eq("sparkInit2"), anyString());
+                eq("space-key: key111; space-name: space name; start-view: space-admin;"), anyString());
 
         // small sanity check that action was really completed as expected
         genBody = otherIframeContextOverrideTest.getBodyAsHtml();


### PR DESCRIPTION
Add the context information that the document in the iframe can use in a known path in the host window instead of trying to inject it directly to the contentWindow of the iframe.

In this way the data is always available before the iframe content can be loaded and it is also resilient to reloads of the iframe content.

In current version the data is stored as an extra field on the iframe DOM element. The iframe element can be accessed from inside the iframe as window.frameElement (as long as the iframe context and the host are on the same domain).

SPARK framework injects helper code into the loaded iframe so that the context information can be accessed using 'SPARK.getContextData()' or 'SPARK.getDialogControls()'.