### PR TITLE
DEV-54: Replaced usage of OSGi BundleContextAware with Spring's Appli…

### DIFF
--- a/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianAppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianAppServlet.java
@@ -7,7 +7,9 @@ import com.atlassian.sal.api.UrlMode;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.message.LocaleResolver;
 import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.sal.api.user.UserProfile;
 import com.atlassian.templaterenderer.TemplateRenderer;
+import com.google.common.base.Preconditions;
 import com.k15t.spark.base.AppServlet;
 import com.k15t.spark.base.RequestProperties;
 import com.k15t.spark.base.util.DocumentOutputUtil;
@@ -17,9 +19,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
-import org.osgi.framework.BundleContext;
-import org.osgi.util.tracker.ServiceTracker;
-import org.springframework.osgi.context.BundleContextAware;
+import org.springframework.context.ApplicationContext;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
@@ -33,16 +33,29 @@ import java.util.Locale;
 import java.util.Map;
 
 
-abstract public class AtlassianAppServlet extends AppServlet implements BundleContextAware {
+public abstract class AtlassianAppServlet extends AppServlet {
 
-    private ServiceTracker loginUriProviderTracker;
-    private ServiceTracker userManagerTracker;
-    private ServiceTracker templateRendererTracker;
-    private ServiceTracker localeResolverTracker;
-    private ServiceTracker applicationProperties;
+    private final LoginUriProvider loginUriProvider;
+    private final UserManager userManager;
+    private final TemplateRenderer templateRenderer;
+    private final LocaleResolver localeResolver;
+    private final ApplicationProperties applicationProperties;
+    private final long pluginModifiedTimestamp;
 
     private String appPrefix;
-    private long pluginModifiedTimestamp;
+
+
+    protected AtlassianAppServlet(LoginUriProvider loginUriProvider, UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
+
+        this.loginUriProvider = Preconditions.checkNotNull(loginUriProvider);
+        this.userManager = Preconditions.checkNotNull(userManager);
+        this.templateRenderer = Preconditions.checkNotNull(templateRenderer);
+        this.localeResolver = Preconditions.checkNotNull(localeResolver);
+        this.applicationProperties = Preconditions.checkNotNull(applicationProperties);
+
+        this.pluginModifiedTimestamp = Preconditions.checkNotNull(applicationContext).getStartupDate();
+    }
 
 
     @Override
@@ -96,21 +109,20 @@ abstract public class AtlassianAppServlet extends AppServlet implements BundleCo
 
     @Override
     protected RequestProperties getRequestProperties(HttpServletRequest request) {
-        return new AtlassianRequestProperties(this, request, getApplicationProperties().getBaseUrl(
-                UrlMode.RELATIVE_CANONICAL), appPrefix, getLocaleResolver().getLocale(request));
+        return new AtlassianRequestProperties(this, request, applicationProperties.getBaseUrl(UrlMode.RELATIVE_CANONICAL), appPrefix,
+                localeResolver.getLocale(request));
     }
 
 
     protected boolean isHtmlContentType(String contentType) {
-        return StringUtils.substringBefore(contentType, ";").equals("text/html");
+        return "text/html".equals(StringUtils.substringBefore(contentType, ";"));
     }
 
 
     @Override
     protected String renderVelocity(String template, RequestProperties props) throws IOException {
         Map<String, Object> context = getVelocityContext(props.getRequest());
-        String rendered = getTemplateRenderer().renderFragment(template, context);
-        return rendered;
+        return templateRenderer.renderFragment(template, context);
     }
 
 
@@ -155,7 +167,7 @@ abstract public class AtlassianAppServlet extends AppServlet implements BundleCo
 
 
     protected void applyCacheKeysToResourceUrls(Document document, RequestProperties props) {
-        Locale locale = getLocaleResolver().getLocale(props.getRequest());
+        Locale locale = localeResolver.getLocale(props.getRequest());
         DocumentOutputUtil.applyCacheKeysToResourceUrls(document, pluginModifiedTimestamp, locale);
     }
 
@@ -228,100 +240,18 @@ abstract public class AtlassianAppServlet extends AppServlet implements BundleCo
 
 
     protected boolean isAnonymous(RequestProperties props) {
-        return getUserManager().getRemoteUsername(props.getRequest()) == null;
+        return userManager.getRemoteUser(props.getRequest()) == null;
     }
 
 
     protected boolean hasPermissions(RequestProperties props) {
-        String user = getUserManager().getRemoteUsername(props.getRequest());
-        return (user != null && getUserManager().isSystemAdmin(user));
+        UserProfile user = userManager.getRemoteUser(props.getRequest());
+        return (user != null && userManager.isSystemAdmin(user.getUserKey()));
     }
 
 
     private void redirectToLogin(RequestProperties props, HttpServletResponse response) throws IOException {
-        response.sendRedirect(getLoginUriProvider().getLoginUri(props.getUri()).toASCIIString());
-    }
-
-
-    @Override
-    public void setBundleContext(BundleContext bundleContext) {
-        pluginModifiedTimestamp = bundleContext.getBundle().getLastModified();
-
-        loginUriProviderTracker = new ServiceTracker(bundleContext, LoginUriProvider.class.getName(), null);
-        loginUriProviderTracker.open();
-
-        userManagerTracker = new ServiceTracker(bundleContext, UserManager.class.getName(), null);
-        userManagerTracker.open();
-
-        templateRendererTracker = new ServiceTracker(bundleContext, TemplateRenderer.class.getName(), null);
-        templateRendererTracker.open();
-
-        localeResolverTracker = new ServiceTracker(bundleContext, LocaleResolver.class.getName(), null);
-        localeResolverTracker.open();
-
-        applicationProperties = new ServiceTracker(bundleContext, ApplicationProperties.class.getName(), null);
-        applicationProperties.open();
-    }
-
-
-    protected LoginUriProvider getLoginUriProvider() {
-        Object proxy = loginUriProviderTracker.getService();
-        if ((proxy != null) && (proxy instanceof LoginUriProvider)) {
-            return (LoginUriProvider) proxy;
-        } else {
-            throw new RuntimeException("Could not get a valid LoginUriProvider proxy.");
-        }
-    }
-
-
-    protected UserManager getUserManager() {
-        Object proxy = userManagerTracker.getService();
-        if ((proxy != null) && (proxy instanceof UserManager)) {
-            return (UserManager) proxy;
-        } else {
-            throw new RuntimeException("Could not get a valid UserManager proxy.");
-        }
-    }
-
-
-    protected TemplateRenderer getTemplateRenderer() {
-        Object proxy = templateRendererTracker.getService();
-        if ((proxy != null) && (proxy instanceof TemplateRenderer)) {
-            return (TemplateRenderer) proxy;
-        } else {
-            throw new RuntimeException("Could not get a valid TemplateRenderer proxy.");
-        }
-    }
-
-
-    protected LocaleResolver getLocaleResolver() {
-        Object proxy = localeResolverTracker.getService();
-        if ((proxy != null) && (proxy instanceof LocaleResolver)) {
-            return (LocaleResolver) proxy;
-        } else {
-            throw new RuntimeException("Could not get a valid LocaleResolver proxy.");
-        }
-    }
-
-
-    protected ApplicationProperties getApplicationProperties() {
-        Object proxy = applicationProperties.getService();
-        if ((proxy != null) && (proxy instanceof ApplicationProperties)) {
-            return (ApplicationProperties) proxy;
-        } else {
-            throw new RuntimeException("Could not get a valid ApplicationProperties proxy.");
-        }
-    }
-
-
-    @Override
-    public void destroy() {
-        super.destroy();
-        loginUriProviderTracker.close();
-        userManagerTracker.close();
-        templateRendererTracker.close();
-        localeResolverTracker.close();
-        applicationProperties.close();
+        response.sendRedirect(loginUriProvider.getLoginUri(props.getUri()).toASCIIString());
     }
 
 }

--- a/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeContentServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeContentServlet.java
@@ -1,9 +1,15 @@
 package com.k15t.spark.atlassian;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.base.RequestProperties;
 import com.k15t.spark.base.util.DocumentOutputUtil;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.springframework.context.ApplicationContext;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -14,6 +20,14 @@ import java.io.IOException;
  * The servlet implementation (or sub-class) to use for SPARK iframe functionality.
  */
 public abstract class AtlassianIframeContentServlet extends AtlassianAppServlet {
+
+    protected AtlassianIframeContentServlet(LoginUriProvider loginUriProvider,
+            UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties,
+            ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
     // AtlassianAppServlet handles some heavy lifting required for living in the plugin servlet environment
     // eg. finding out the real servlet path and handling caching in that environment

--- a/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
@@ -36,7 +36,7 @@ import java.util.Set;
  * </ul>
  */
 
-abstract public class AppServlet extends HttpServlet {
+public abstract class AppServlet extends HttpServlet {
 
     protected final Set<String> VELOCITY_TYPES = Collections.unmodifiableSet(new HashSet<String>() {{
         add("text/html");

--- a/spark-confluence/pom.xml
+++ b/spark-confluence/pom.xml
@@ -27,22 +27,36 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Provided by confluence -->
-        <dependency>
-            <groupId>org.springframework.osgi</groupId>
-            <artifactId>spring-osgi-core</artifactId>
-            <version>1.1.3</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
-            <version>${confluence.version}</version>
-            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.sal</groupId>
+            <artifactId>sal-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.templaterenderer</groupId>
+            <artifactId>atlassian-template-renderer-api</artifactId>
         </dependency>
     </dependencies>
 
-    <properties>
-        <confluence.version>5.3</confluence.version>
-    </properties>
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- Confluence-provided dependencies. -->
+            <dependency>
+                <groupId>com.k15t.scroll.dependencies</groupId>
+                <artifactId>confluence-dep-5-10</artifactId>
+                <version>3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceAppServlet.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceAppServlet.java
@@ -1,6 +1,12 @@
 package com.k15t.spark.confluence;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianAppServlet;
+import org.springframework.context.ApplicationContext;
 
 
 /**
@@ -8,5 +14,13 @@ import com.k15t.spark.atlassian.AtlassianAppServlet;
  */
 @Deprecated
 public class ConfluenceAppServlet extends AtlassianAppServlet {
+
+    protected ConfluenceAppServlet(LoginUriProvider loginUriProvider,
+            UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties,
+            ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
 }

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeContentServlet.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeContentServlet.java
@@ -1,6 +1,12 @@
 package com.k15t.spark.confluence;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianIframeContentServlet;
+import org.springframework.context.ApplicationContext;
 
 
 /**
@@ -8,5 +14,13 @@ import com.k15t.spark.atlassian.AtlassianIframeContentServlet;
  */
 @Deprecated
 public class ConfluenceIframeContentServlet extends AtlassianIframeContentServlet {
+
+    protected ConfluenceIframeContentServlet(LoginUriProvider loginUriProvider,
+            UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties,
+            ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
 }

--- a/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppServlet.java
+++ b/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppServlet.java
@@ -1,6 +1,12 @@
 package com.k15t.spark.jira;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianAppServlet;
+import org.springframework.context.ApplicationContext;
 
 
 /**
@@ -8,5 +14,11 @@ import com.k15t.spark.atlassian.AtlassianAppServlet;
  */
 @Deprecated
 public class JiraAppServlet extends AtlassianAppServlet {
+
+    protected JiraAppServlet(LoginUriProvider loginUriProvider, UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
 }

--- a/spark-jira/src/main/java/com/k15t/spark/jira/JiraIframeContentServlet.java
+++ b/spark-jira/src/main/java/com/k15t/spark/jira/JiraIframeContentServlet.java
@@ -1,6 +1,12 @@
 package com.k15t.spark.jira;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianIframeContentServlet;
+import org.springframework.context.ApplicationContext;
 
 
 /**
@@ -8,5 +14,11 @@ import com.k15t.spark.atlassian.AtlassianIframeContentServlet;
  */
 @Deprecated
 public class JiraIframeContentServlet extends AtlassianIframeContentServlet {
+
+    protected JiraIframeContentServlet(LoginUriProvider loginUriProvider, UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
 }


### PR DESCRIPTION
…cationContext. Also made DI explicit in spark servlets.

- Our dependency to the OSGi interface {{BundleContextAware}} required all projects using spark to declare a dependency to a deprecated compatibility library that will go away in future versions of the plugin system. This replaces all code using that interface so it uses spring interfaces instead.
- Also made the dependency injection of the spark servlets more explicit, so developers creating project-specific subclasses must think about OSGi-importing the respective components.