### PR TITLE
Dev 69 confluence 7 compatibility spark 1 x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
-            <version>2.10.0</version>
+            <version>3.0.3</version>
             <scope>provided</scope>
         </dependency>
 
@@ -104,8 +104,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>

--- a/spark-common/pom.xml
+++ b/spark-common/pom.xml
@@ -16,38 +16,20 @@
             <!-- jsoup HTML parser library @ http://jsoup.org/ -->
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.7.3</version>
+            <version>1.9.2</version>
         </dependency>
 
         <!-- Scope: Provided -->
         <dependency>
-            <groupId>org.springframework.osgi</groupId>
-            <artifactId>spring-osgi-core</artifactId>
-            <version>1.1.3</version>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>4.1.6.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.templaterenderer</groupId>
             <artifactId>atlassian-template-renderer-api</artifactId>
-            <version>1.3.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugins</groupId>
-            <artifactId>atlassian-plugins-osgi</artifactId>
-            <version>2.13.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugins</groupId>
-            <artifactId>atlassian-plugins-servlet</artifactId>
-            <version>2.13.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugins</groupId>
-            <artifactId>atlassian-plugins-webfragment</artifactId>
-            <version>2.13.4</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -57,39 +39,27 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugins.rest</groupId>
-            <artifactId>atlassian-rest-common</artifactId>
-            <version>2.6.7</version>
+            <groupId>com.atlassian.plugins</groupId>
+            <artifactId>atlassian-plugins-servlet</artifactId>
+            <version>4.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.4.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
-            <version>1.4.4</version>
+            <version>1.9.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>10.0.1</version>
+            <version>18.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -105,6 +75,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
                 <executions>
                     <execution>
                         <phase>site</phase>

--- a/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -136,13 +137,13 @@ abstract public class AppServlet extends HttpServlet {
 
         String shortType = StringUtils.substringBefore(props.getContentType(), ";");
         if (VELOCITY_TYPES.contains(shortType)) {
-            String result = renderVelocity(IOUtils.toString(resource, "UTF-8"), props);
+            String result = renderVelocity(IOUtils.toString(resource, StandardCharsets.UTF_8), props);
 
             if ("index.html".equals(props.getLocalPath())) {
                 result = prepareIndexHtml(result, props);
             }
 
-            IOUtils.write(result, response.getOutputStream());
+            IOUtils.write(result, response.getOutputStream(), StandardCharsets.UTF_8);
 
         } else {
             IOUtils.copy(resource, response.getOutputStream());

--- a/spark-common/src/main/resources/com/k15t/spark/spark-bootstrap.js
+++ b/spark-common/src/main/resources/com/k15t/spark/spark-bootstrap.js
@@ -1,148 +1,151 @@
-AJS.toInit(function($) {
+;(function(AJS, $) {
 
-    'use strict';
+    AJS.toInit(function() {
 
-
-    function AppLoader() {
-
-        var startedApps = {};
+        'use strict';
 
 
-        /**
-         * Creates an angular based dialog.
-         *
-         * @param element Dom element under which the angular application should be attached and bootstrapped
-         * @param angularAppName Name of the angular application to bootstrap
-         * @param appPath application path which will be used to load the necessary angular resources
-         * @param callbackStarted Callback which will be called after the angular application was successfully started
-         */
-        this.createDialog = function(element, angularAppName, appPath, callbackStarted) {
+        function AppLoader() {
 
-            // append trailing slash if not there.
-            var fullAppPath = contextPath + (/\/$/.test(appPath) ? appPath : appPath + '/');
+            var startedApps = {};
 
-            var elementIdSparkAppContainer = angularAppName + '-dialog-container';
-            var appContainerAlreadyCreated = $('#' + elementIdSparkAppContainer).length > 0;
 
-            if (appContainerAlreadyCreated) {
-                $('#' + elementIdSparkAppContainer).remove();
-            }
+            /**
+             * Creates an angular based dialog.
+             *
+             * @param element Dom element under which the angular application should be attached and bootstrapped
+             * @param angularAppName Name of the angular application to bootstrap
+             * @param appPath application path which will be used to load the necessary angular resources
+             * @param callbackStarted Callback which will be called after the angular application was successfully started
+             */
+            this.createDialog = function(element, angularAppName, appPath, callbackStarted) {
 
-            $(element).append(SPARK.Common.Templates.appBootstrapContainer({
-                containerId: elementIdSparkAppContainer
-            }));
+                // append trailing slash if not there.
+                var fullAppPath = contextPath + (/\/$/.test(appPath) ? appPath : appPath + '/');
 
-            // We have to use an additional element (div#spark-dialog-app-wrapper),
-            // because body doesn't work, because it is using the browsers .innerHtml
-            // property, which doesn't work consistently across browsers and for
-            // example in Chrome includes elements from head, too. The additional
-            // element is inserted automatically by the AppServlet.
-            // More info: https://api.jquery.com/load/#loading-page-fragments
-            $('#' + elementIdSparkAppContainer, element).load(
-                fullAppPath + ' div#spark-dialog-app-wrapper > *', function complete(response, status, xhr) {
+                var elementIdSparkAppContainer = angularAppName + '-dialog-container';
+                var appContainerAlreadyCreated = $('#' + elementIdSparkAppContainer).length > 0;
 
-                    if (status == "error") {
-                        var dialog = createErrorDialog(angularAppName);
-                        var absoluteAppPath = location.protocol + '//' + location.host + fullAppPath;
-                        dialog.$titleEl.html('Error');
-                        dialog.$contentEl.html(
-                            '<h2>Could not load dialog app from \'' + fullAppPath + '\'</h2>' +
-                            '<p>Have you created a servlet module for the DialogAppServlet in <code>atlassian-plugin.xml</code>?</p>' +
-                            '<p>It should be available at <a href="' + fullAppPath + '">' + absoluteAppPath + '</a></p>'
-                        );
-                        dialog.show();
+                if (appContainerAlreadyCreated) {
+                    $('#' + elementIdSparkAppContainer).remove();
+                }
 
-                        AJS.$('#closeErrorDialogButton').click(function(e) {
-                            e.preventDefault();
-                            dialog.hide();
-                        });
-
-                    } else {
-
-                        var angular = (window.angular = {});
-
-                        if (startedApps[angularAppName]) {
-                            delete startedApps[angularAppName];
-                        }
-
-                        var scriptsToLoad = getExtractScriptsFromElement(element);
-                        if (scriptsToLoad && scriptsToLoad.length > 0) {
-                            // https://github.com/rgrove/lazyload
-                            LazyLoad.js(scriptsToLoad, function() {
-                                angular = window.angular;
-                                startedApps[angularAppName] = angular.bootstrap($('#' + angularAppName, element), [angularAppName]);
-                                if (callbackStarted) {
-                                    callbackStarted(angular);
-                                }
-                            });
-                        }
-                    }
-                });
-        };
-
-        /**
-         * Gets the bootstrapped angular application
-         *
-         * @param angularAppName Name of the angular application
-         * @returns {*} Angular application or undefined if there is no application registered with that name
-         */
-        this.getApp = function(angularAppName) {
-            return startedApps[angularAppName];
-        };
-
-        var createErrorDialog = function(dialogId) {
-
-            var dialog;
-
-            if (AJS.dialog2) {
-                $('body').append(SPARK.Common.Templates.errorDialog2({
-                    dialogId: dialogId
+                $(element).append(SPARK.Common.Templates.appBootstrapContainer({
+                    containerId: elementIdSparkAppContainer
                 }));
-                dialog = AJS.dialog2('#' + dialogId);
-                dialog.$appEl = dialog.$el;
-                dialog.$titleEl = $('h2:contains({{app.title}})', dialog.$appEl);
-                dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
 
-            } else {
-                dialog = new AJS.Dialog({
-                    width: 800,
-                    height: 500,
-                    id: dialogId
+                // We have to use an additional element (div#spark-dialog-app-wrapper),
+                // because body doesn't work, because it is using the browsers .innerHtml
+                // property, which doesn't work consistently across browsers and for
+                // example in Chrome includes elements from head, too. The additional
+                // element is inserted automatically by the AppServlet.
+                // More info: https://api.jquery.com/load/#loading-page-fragments
+                $('#' + elementIdSparkAppContainer, element).load(
+                    fullAppPath + ' div#spark-dialog-app-wrapper > *', function complete(response, status, xhr) {
+
+                        if (status == "error") {
+                            var dialog = createErrorDialog(angularAppName);
+                            var absoluteAppPath = location.protocol + '//' + location.host + fullAppPath;
+                            dialog.$titleEl.html('Error');
+                            dialog.$contentEl.html(
+                                '<h2>Could not load dialog app from \'' + fullAppPath + '\'</h2>' +
+                                '<p>Have you created a servlet module for the DialogAppServlet in <code>atlassian-plugin.xml</code>?</p>' +
+                                '<p>It should be available at <a href="' + fullAppPath + '">' + absoluteAppPath + '</a></p>'
+                            );
+                            dialog.show();
+
+                            AJS.$('#closeErrorDialogButton').click(function(e) {
+                                e.preventDefault();
+                                dialog.hide();
+                            });
+
+                        } else {
+
+                            var angular = (window.angular = {});
+
+                            if (startedApps[angularAppName]) {
+                                delete startedApps[angularAppName];
+                            }
+
+                            var scriptsToLoad = getExtractScriptsFromElement(element);
+                            if (scriptsToLoad && scriptsToLoad.length > 0) {
+                                // https://github.com/rgrove/lazyload
+                                LazyLoad.js(scriptsToLoad, function() {
+                                    angular = window.angular;
+                                    startedApps[angularAppName] = angular.bootstrap($('#' + angularAppName, element), [angularAppName]);
+                                    if (callbackStarted) {
+                                        callbackStarted(angular);
+                                    }
+                                });
+                            }
+                        }
+                    });
+            };
+
+            /**
+             * Gets the bootstrapped angular application
+             *
+             * @param angularAppName Name of the angular application
+             * @returns {*} Angular application or undefined if there is no application registered with that name
+             */
+            this.getApp = function(angularAppName) {
+                return startedApps[angularAppName];
+            };
+
+            var createErrorDialog = function(dialogId) {
+
+                var dialog;
+
+                if (AJS.dialog2) {
+                    $('body').append(SPARK.Common.Templates.errorDialog2({
+                        dialogId: dialogId
+                    }));
+                    dialog = AJS.dialog2('#' + dialogId);
+                    dialog.$appEl = dialog.$el;
+                    dialog.$titleEl = $('h2:contains({{app.title}})', dialog.$appEl);
+                    dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
+
+                } else {
+                    dialog = new AJS.Dialog({
+                        width: 800,
+                        height: 500,
+                        id: dialogId
+                    });
+                    dialog.$appEl = dialog.popup.element;
+                    dialog.$appEl.html(SPARK.Common.Templates.errorDialog());
+                    dialog.$titleEl = $('h2:contains({{app.title}})', dialog.$appEl);
+                    dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
+                    dialog.$contentEl.height(dialog.$appEl.height() - 105);
+                }
+
+                $('.aui-blanket').addClass('spark-loading');
+
+                return dialog;
+            };
+
+
+            var getExtractScriptsFromElement = function($contentEl) {
+
+                var scripts = [];
+
+                $('meta[name=script]', $contentEl).each(function() {
+                    scripts.push($(this).attr('content'));
+                    $(this).remove();
                 });
-                dialog.$appEl = dialog.popup.element;
-                dialog.$appEl.html(SPARK.Common.Templates.errorDialog());
-                dialog.$titleEl = $('h2:contains({{app.title}})', dialog.$appEl);
-                dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
-                dialog.$contentEl.height(dialog.$appEl.height() - 105);
-            }
 
-            $('.aui-blanket').addClass('spark-loading');
+                return scripts;
+            };
+        }
 
-            return dialog;
-        };
+        // init SPARK context ==================================================================
 
+        if (window.SPARK === undefined) {
+            window.SPARK = {};
+        }
 
-        var getExtractScriptsFromElement = function($contentEl) {
+        if (window.SPARK.appLoader === undefined) {
+            window.SPARK.appLoader = new AppLoader();
+        }
 
-            var scripts = [];
-
-            $('meta[name=script]', $contentEl).each(function() {
-                scripts.push($(this).attr('content'));
-                $(this).remove();
-            });
-
-            return scripts;
-        };
-    }
-
-    // init SPARK context ==================================================================
-
-    if(window.SPARK === undefined) {
-        window.SPARK = {};
-    }
-
-    if (window.SPARK.appLoader === undefined) {
-        window.SPARK.appLoader = new AppLoader();
-    }
-
-})(AJS.$);
+    });
+}(require('ajs'), require('jquery')));

--- a/spark-confluence/pom.xml
+++ b/spark-confluence/pom.xml
@@ -13,9 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>spark-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>
@@ -27,22 +27,36 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Provided by confluence -->
-        <dependency>
-            <groupId>org.springframework.osgi</groupId>
-            <artifactId>spring-osgi-core</artifactId>
-            <version>1.1.3</version>
-            <scope>provided</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.atlassian.confluence</groupId>
             <artifactId>confluence</artifactId>
-            <version>${confluence.version}</version>
-            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.sal</groupId>
+            <artifactId>sal-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.atlassian.templaterenderer</groupId>
+            <artifactId>atlassian-template-renderer-api</artifactId>
         </dependency>
     </dependencies>
 
-    <properties>
-        <confluence.version>5.3</confluence.version>
-    </properties>
+    <dependencyManagement>
+        <dependencies>
+
+            <!-- Confluence-provided dependencies. -->
+            <dependency>
+                <groupId>com.k15t.scroll.dependencies</groupId>
+                <artifactId>confluence-dep-6-0</artifactId>
+                <version>5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceAppServlet.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceAppServlet.java
@@ -1,7 +1,13 @@
 package com.k15t.spark.confluence;
 
 import com.atlassian.confluence.core.ConfluenceSystemProperties;
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianAppServlet;
+import org.springframework.context.ApplicationContext;
 
 
 public class ConfluenceAppServlet extends AtlassianAppServlet {
@@ -11,6 +17,14 @@ public class ConfluenceAppServlet extends AtlassianAppServlet {
      * "confluence.dev.mode" is not included in {@link ConfluenceSystemProperties#isDevMode()}.
      */
     public final static String QUIRKY_DEV_MODE = "confluence.dev.mode";
+
+    protected ConfluenceAppServlet(LoginUriProvider loginUriProvider,
+            UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties,
+            ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
 
 
     @Override

--- a/spark-jira/pom.xml
+++ b/spark-jira/pom.xml
@@ -13,9 +13,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId}</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>spark-common</artifactId>
-            <version>${version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>
@@ -27,11 +27,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Provided by confluence -->
+        <!-- Provided by jira -->
         <dependency>
-            <groupId>org.springframework.osgi</groupId>
-            <artifactId>spring-osgi-core</artifactId>
-            <version>1.1.3</version>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>4.1.6.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -40,9 +40,15 @@
             <version>${jira.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.atlassian.templaterenderer</groupId>
+            <artifactId>atlassian-template-renderer-api</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <properties>
-        <jira.version>6.1</jira.version>
+        <jira.version>7.0.0</jira.version>
     </properties>
 </project>

--- a/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppServlet.java
+++ b/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppServlet.java
@@ -1,10 +1,24 @@
 package com.k15t.spark.jira;
 
+import com.atlassian.sal.api.ApplicationProperties;
+import com.atlassian.sal.api.auth.LoginUriProvider;
+import com.atlassian.sal.api.message.LocaleResolver;
+import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.atlassian.AtlassianAppServlet;
+import org.springframework.context.ApplicationContext;
 import org.apache.commons.lang.BooleanUtils;
 
 
 public class JiraAppServlet extends AtlassianAppServlet {
+
+
+    protected JiraAppServlet(LoginUriProvider loginUriProvider, UserManager userManager, TemplateRenderer templateRenderer,
+            LocaleResolver localeResolver, ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
+
+        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+    }
+
 
     @Override
     protected boolean isDevMode() {


### PR DESCRIPTION
- update JS code to require AJS and $ instead of using globals
- update versions to Jira 7 and Confluence 6 (and dependencies packaged with these versions)
- remove usage of BundleContextAware (is an 2.x branch)
- remove usages of deprecated methods