### PR TITLE
Dev 69 replace usage of js globals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>com.atlassian.sal</groupId>
             <artifactId>sal-api</artifactId>
-            <version>2.10.0</version>
+            <version>3.0.3</version>
             <scope>provided</scope>
         </dependency>
 

--- a/spark-common/pom.xml
+++ b/spark-common/pom.xml
@@ -16,50 +16,44 @@
             <!-- jsoup HTML parser library @ http://jsoup.org/ -->
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.7.3</version>
+            <version>1.9.2</version>
         </dependency>
 
         <!-- Scope: Provided -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>2.5.5</version>
+            <version>4.1.6.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.templaterenderer</groupId>
             <artifactId>atlassian-template-renderer-api</artifactId>
-            <version>1.3.1</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.plugins</groupId>
             <artifactId>atlassian-plugins-servlet</artifactId>
-            <version>2.13.4</version>
+            <version>4.0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.4.4</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-xc</artifactId>
-            <version>1.4.4</version>
+            <version>1.9.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>10.0.1</version>
+            <version>18.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/base/AppServlet.java
@@ -13,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -154,13 +155,13 @@ public abstract class AppServlet extends HttpServlet {
 
         String shortType = StringUtils.substringBefore(props.getContentType(), ";");
         if (VELOCITY_TYPES.contains(shortType)) {
-            String result = renderVelocity(IOUtils.toString(resource, "UTF-8"), props);
+            String result = renderVelocity(IOUtils.toString(resource, StandardCharsets.UTF_8), props);
 
             if ("index.html".equals(props.getLocalPath())) {
                 result = prepareIndexHtml(result, props);
             }
 
-            IOUtils.write(result, response.getOutputStream());
+            IOUtils.write(result, response.getOutputStream(), StandardCharsets.UTF_8);
 
         } else {
             IOUtils.copy(resource, response.getOutputStream());

--- a/spark-common/src/main/js/test/mocks/spark-dep-mocks.js
+++ b/spark-common/src/main/js/test/mocks/spark-dep-mocks.js
@@ -7,7 +7,15 @@
 var AJS = AJS || {}; // add a AJS mock as global and needed functions
 var $ = $ || {};
 
-AJS.$ = $;
+var require = function(module) {
+    if (module === 'ajs') {
+        return AJS;
+    } else if (module === 'jquery') {
+        return $;
+    } else {
+        throw new Error('unimplement module: ' + module);
+    }
+};
 
 var SPARK = { 'mockupOldVersion': true };
 

--- a/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
+++ b/spark-common/src/main/js/test/specs/iframeAppLoaderSpec.js
@@ -857,7 +857,7 @@ describe('iframeAppLoader', function() {
             it('checks the target of  the triggerElement is equal to the id of the dialogElement', function() {
                 var { triggerEl } = this.inlineDialogOpener('test-app-name', '/test/app/path', {});
 
-                expect(AJS.$(triggerEl).attr('aria-controls')).toEqual('test-app-name-spark-app-container');
+                expect($(triggerEl).attr('aria-controls')).toEqual('test-app-name-spark-app-container');
 
             });
         });

--- a/spark-common/src/main/js/webpack.config.js
+++ b/spark-common/src/main/js/webpack.config.js
@@ -54,8 +54,8 @@ module.exports = [
             path: distDir
         },
         externals: {
-            jquery: 'AJS.$',
-            ajs: 'AJS'
+            jquery: "window.require('jquery')",
+            ajs: "window.require('ajs')"
         }
     }),
     Object.assign({}, baseConfig, {

--- a/spark-confluence/pom.xml
+++ b/spark-confluence/pom.xml
@@ -50,8 +50,8 @@
             <!-- Confluence-provided dependencies. -->
             <dependency>
                 <groupId>com.k15t.scroll.dependencies</groupId>
-                <artifactId>confluence-dep-5-10</artifactId>
-                <version>3</version>
+                <artifactId>confluence-dep-6-0</artifactId>
+                <version>5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSparkActionHelper.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSparkActionHelper.java
@@ -39,7 +39,7 @@ public class ConfluenceIframeSparkActionHelper {
                             instance.getSpaBaseUrl(), baseIframeId + idSuffix,
                             instance.getIframeContextInfo(), instance.getSpaQueryString());
 
-            return VelocityUtils.getRenderedContent(template, context);
+            return VelocityUtils.getRenderedContent((CharSequence) template, context);
         } catch (IOException e) {
             throw new RuntimeException("Cannot load iframe-space app template");
         }

--- a/spark-confluence/src/test/java/com/k15t/spark/confluence/ConfluenceSpaceAppActionTestCommon.java
+++ b/spark-confluence/src/test/java/com/k15t/spark/confluence/ConfluenceSpaceAppActionTestCommon.java
@@ -84,7 +84,7 @@ public class ConfluenceSpaceAppActionTestCommon {
         // Mock up the conflunce velocity util
         PowerMockito.mockStatic(VelocityUtils.class);
 
-        Mockito.when(VelocityUtils.getRenderedContent(anyString(), Mockito.anyMap())).
+        Mockito.when(VelocityUtils.getRenderedContent((CharSequence) anyString(), Mockito.anyMap())).
                 thenReturn(renderedVelocityToReturn);
 
 

--- a/spark-confluence/src/test/java/com/k15t/spark/confluence/ConflunceIframeSparkActionHelperTest.java
+++ b/spark-confluence/src/test/java/com/k15t/spark/confluence/ConflunceIframeSparkActionHelperTest.java
@@ -96,7 +96,7 @@ public class ConflunceIframeSparkActionHelperTest extends ConfluenceSpaceAppActi
         // not very ideal test because ties how the rendering is expected to be done which is unimportant...
         // on the other hand making the VelocityUtils call without mocking it would require lots of other setup
         PowerMockito.verifyStatic(times(1));
-        VelocityUtils.getRenderedContent(velocityTemplateToReturn, velocityContextToReturn);
+        VelocityUtils.getRenderedContent((CharSequence) velocityTemplateToReturn, velocityContextToReturn);
 
         // expect to return the 'rendered' content
         Assert.assertEquals(renderedVelocityToReturn, result);

--- a/spark-jira/pom.xml
+++ b/spark-jira/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>2.5.5</version>
+            <version>4.1.6.RELEASE</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -43,12 +43,12 @@
         <dependency>
             <groupId>com.atlassian.templaterenderer</groupId>
             <artifactId>atlassian-template-renderer-api</artifactId>
-            <version>1.4.4-m1</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <properties>
-        <jira.version>6.3.15</jira.version>
+        <jira.version>7.0.0</jira.version>
     </properties>
 </project>


### PR DESCRIPTION
- use (synchronous) require instead of globals to access AJS and $
- update dependencies to Confluence 6 and Jira 7
- remove usage of deprecated methods