### PR TITLE
Dev 67 escape inputs to templates

### DIFF
--- a/spark-common/src/main/js/src/spark-bootstrap.js
+++ b/spark-common/src/main/js/src/spark-bootstrap.js
@@ -166,20 +166,11 @@ function AppLoader() {
 
 
     var createErrorDialog = function(id) {
-        var dialog;
-
-        if (AJS.dialog2) {
-            dialog = createDialog(id, sparkTemplates.errorDialog2({
-                id: id,
-                title: 'An error happened ...',
-                className: css.className
-            }));
-        } else {
-            dialog = createDialog(id, sparkTemplates.errorDialog({
-                title: 'An error happened ...',
-                className: css.className
-            }), 800, 500);
-        }
+        var dialog = createDialog(id, sparkTemplates.errorDialog2({
+            id: id,
+            title: 'An error happened ...',
+            className: css.className
+        }));
 
         $('.aui-blanket').addClass('spark-loading');
 
@@ -189,24 +180,10 @@ function AppLoader() {
 
     var createDialog = function(id, dialogMarkup, cssClass, width, height) {
 
-        var dialog;
-
-        if (AJS.dialog2) {
-            $('body').append(dialogMarkup);
-            dialog = AJS.dialog2('#' + id);
-            dialog.$appEl = dialog.$el;
-            dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
-        } else {
-            dialog = new AJS.Dialog({
-                width: width,
-                height: height,
-                id: id
-            });
-            dialog.$appEl = dialog.popup.element;
-            dialog.$appEl.html(dialogMarkup);
-            dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
-            dialog.$contentEl.height(dialog.$appEl.height() - 105);
-        }
+        $('body').append(dialogMarkup);
+        var dialog = AJS.dialog2('#' + id);
+        dialog.$appEl = dialog.$el;
+        dialog.$contentEl = $('.spark-app-content', dialog.$appEl);
 
         return dialog;
     };

--- a/spark-common/src/main/js/src/spark-common-templates.js
+++ b/spark-common/src/main/js/src/spark-common-templates.js
@@ -72,27 +72,6 @@ const errorDialog2 = function({id, title, className}) {
 
 
 /**
- * Template to create an error dialog 1
- *
- * @param title
- * @param className
- */
-const errorDialog = function({title, className}) {
-    return `
-        <div class="dialog-components ${className}">
-            <h2 class="dialog-title">${title}</h2>
-            <div class="dialog-page-body">
-                <div class="dialog-panel-body spark-app-content">
-            </div>
-            </div>
-                <div class="dialog-button-panel">
-                <a href="#" class="button-panel-link button-panel-cancel-link" id="closeErrorDialogButton">Close</a>
-            </div>
-        </div>
-    `;
-};
-
-/**
  * @param id Id of the HTML element
  * @param src URL of the content to load to the iframe
  * @param createOptions extra options to customize the dialog
@@ -174,7 +153,6 @@ export default {
     appBootstrapContaineriFrame,
     appBootstrapContainerDialog2WithiFrame,
     errorDialog2,
-    errorDialog,
     appFullscreenContainerIframe,
     inlineDialogTrigger,
     inlineDialogAppContainer,

--- a/spark-common/src/main/js/src/spark-common-templates.js
+++ b/spark-common/src/main/js/src/spark-common-templates.js
@@ -1,12 +1,34 @@
+const escapeHtml = function(str) {
+    if (!str) {
+        return null;
+    }
+    return str.replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+
+const escapeHtmlMany = function(srcObj, extract) {
+    const res = {};
+    extract.forEach(function(key) {
+        res[key] = escapeHtml(srcObj[key]);
+    });
+    return res;
+}
+
+
 /**
  * @param id Id of the HTML element
  * @param src
  * @param createOptions
  * @param className
  */
-const appBootstrapContaineriFrame = function({id, src, createOptions, className}) {
+const appBootstrapContaineriFrame = function(options) {
+    const { id, src, className } = escapeHtmlMany(options, ['id', 'src', 'className']);
+    const width = escapeHtml(options.createOptions.width);
     return `
-        <iframe id="${id}-iframe" class="${className} spark-app-iframe" src="${src}" width="${createOptions.width}"
+        <iframe id="${id}-iframe" class="${className} spark-app-iframe" src="${src}" width="${width}"
             height="100%" scrolling="no">
         </iframe>
     `;
@@ -21,25 +43,32 @@ const appBootstrapContaineriFrame = function({id, src, createOptions, className}
  * @param createOptions
  * @param className
  */
-const appBootstrapContainerDialog2WithiFrame = function({id, title, src, createOptions, className}) {
+const appBootstrapContainerDialog2WithiFrame = function(options) {
+    const { id, title, src, className } = escapeHtmlMany(options, ['id', 'title', 'src', 'className']);
+    const createOptions = options.createOptions;
+    const width = escapeHtml(createOptions.width);
+    const height = escapeHtml(createOptions.height);
+    const showSubmitButton = !!createOptions.showSubmitButton;
+    const submitLabel = escapeHtml(createOptions.label.submit);
+    const closeLabel = escapeHtml(createOptions.label.close);
     return `
-        <section role="dialog" id="${id}" class="${className} aui-layer aui-dialog2" style="width:${createOptions.width};"
+        <section role="dialog" id="${id}" class="${className} aui-layer aui-dialog2" style="width:${width};"
                 aria-hidden="true">
             <header class="aui-dialog2-header">
                 <h2 class="aui-dialog2-header-main">${title}</h2>
             </header>
             <div class="aui-dialog2-content spark-app-content"
-                    style="padding: 0; width:${createOptions.width}; height: ${createOptions.height}; overflow: hidden;">
-                ${appBootstrapContaineriFrame({id, src, createOptions, className})}
+                    style="padding: 0; width:${width}; height: ${height}; overflow: hidden;">
+                ${appBootstrapContaineriFrame({ id, src, createOptions, className })}
             </div>
             <footer class="aui-dialog2-footer">
                 <div class="aui-dialog2-footer-actions">
-                    ${createOptions.showSubmitButton ?
-                        `<button id="submitDialogButton${id}" class="aui-button aui-button-primary">
-                            ${createOptions.label.submit}
+                    ${showSubmitButton ?
+        `<button id="submitDialogButton${id}" class="aui-button aui-button-primary">
+                            ${submitLabel}
                         </button>`
-                    : ''}
-                    <button id="closeDialogButton${id}" class="aui-button aui-button-link">${createOptions.label.close}</button>
+        : ''}
+                    <button id="closeDialogButton${id}" class="aui-button aui-button-link">${closeLabel}</button>
                 </div>
             </footer>
         </section>
@@ -54,7 +83,8 @@ const appBootstrapContainerDialog2WithiFrame = function({id, title, src, createO
  * @param title
  * @param className
  */
-const errorDialog2 = function({id, title, className}) {
+const errorDialog2 = function(options) {
+    const { id, title, className } = escapeHtmlMany(options, ['id', 'title', 'className']);
     return `
         <section role="dialog" id="${id}" class="${className} aui-layer aui-dialog2 aui-dialog2-medium" aria-hidden="true">
             <header class="aui-dialog2-header">
@@ -77,12 +107,14 @@ const errorDialog2 = function({id, title, className}) {
  * @param createOptions extra options to customize the dialog
  * @param className
  */
-const appFullscreenContainerIframe = function({id, src, createOptions, className}) {
+const appFullscreenContainerIframe = function(options) {
+    const { id, src, className } = escapeHtmlMany(options, ['id', 'src', 'className']);
+    const addChrome = !!options.createOptions.addChrome;
     return `
         <div id="${id}" 
-            class="spark-fullscreen-wrapper ${className} ${createOptions.addChrome ? "spark-fullscreen-dialog" : "" }"
+            class="spark-fullscreen-wrapper ${className} ${addChrome ? "spark-fullscreen-dialog" : ""}"
         >
-            ${createOptions.addChrome ?
+            ${addChrome ?
                 `<div class="spark-fullscreen-chrome">
                     <div class="spark-fullscreen-chrome-btnwrap">
                         <button id="${id}-chrome-submit" class="aui-button aui-icon aui-icon-small aui-iconfont-success">
@@ -94,7 +126,7 @@ const appFullscreenContainerIframe = function({id, src, createOptions, className
                     </div>
                 </div>
             ` : ''}
-            <div class="spark-fullscreen-scroll-wrapper ${createOptions.addChrome ? "spark-fullscreen-haschrome" : ""}">
+            <div class="spark-fullscreen-scroll-wrapper ${addChrome ? "spark-fullscreen-haschrome" : ""}">
                 <iframe id="${id}-iframe" class="spark-fullscreen-iframe" src="${src}" scrolling="no">
                 </iframe>
             </div>
@@ -108,7 +140,8 @@ const appFullscreenContainerIframe = function({id, src, createOptions, className
  * @param targetId id of the controlled inline dialog
  * @param text optional link text
  */
-const inlineDialogTrigger = function({ targetId, text }) {
+const inlineDialogTrigger = function(options) {
+    const { targetId, text } = escapeHtmlMany(options, ['targetId', 'text']);
     return `
         <a data-aui-trigger aria-controls="${targetId}" style="cursor: pointer; color: inherit;">${text}</a>
     `;
@@ -122,11 +155,14 @@ const inlineDialogTrigger = function({ targetId, text }) {
  * @param createOptions supports setting 'alignment' and (initial) 'width' of the inline dialog
  * @param className
  */
-const inlineDialogAppContainer = function({ id, src, createOptions, className }) {
+const inlineDialogAppContainer = function(options) {
+    const { id, src, className } = escapeHtmlMany(options, ['id', 'src', 'className']);
+    const alignment = escapeHtml(options.createOptions.alignment);
+    const width = escapeHtml(options.createOptions.width);
     return `
         <aui-inline-dialog id="${id}" class="spark-inline-wrapper ${className}"
-            alignment="${createOptions.alignment}">
-                <div style="width:${createOptions.width}" id="${id + '-iframe-container'}">
+            alignment="${alignment}">
+                <div style="width:${width}" id="${id + '-iframe-container'}">
                     <iframe id="${id}-iframe" class="${className} spark-iframe" src="${src}" scrolling="no">
                     </iframe>
                 </div>
@@ -142,7 +178,8 @@ const inlineDialogAppContainer = function({ id, src, createOptions, className })
  * @param src URL of the source of the iframe
  * @param className
  */
-const bootstrappedIframe = function({ id, src, className }) {
+const bootstrappedIframe = function(options) {
+    const { id, src, className } = escapeHtmlMany(options, ['id', 'src', 'className']);
     return `
         <iframe id="${id}" class="${className} spark-iframe" src="${src}" scrolling="no">
         </iframe>

--- a/spark-common/src/main/js/src/spark-common-templates.js
+++ b/spark-common/src/main/js/src/spark-common-templates.js
@@ -5,7 +5,8 @@ const escapeHtml = function(str) {
     return str.replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#39;');
+        .replace(/'/g, '&#39;')
+        .replace(/&/g, '&amp;');
 }
 
 
@@ -51,6 +52,10 @@ const appBootstrapContainerDialog2WithiFrame = function(options) {
     const showSubmitButton = !!createOptions.showSubmitButton;
     const submitLabel = escapeHtml(createOptions.label.submit);
     const closeLabel = escapeHtml(createOptions.label.close);
+    // when calling other templates, use unescaped values
+    const idRaw = options.id;
+    const srcRaw = options.src;
+    const classNameRaw = options.className;
     return `
         <section role="dialog" id="${id}" class="${className} aui-layer aui-dialog2" style="width:${width};"
                 aria-hidden="true">
@@ -59,7 +64,7 @@ const appBootstrapContainerDialog2WithiFrame = function(options) {
             </header>
             <div class="aui-dialog2-content spark-app-content"
                     style="padding: 0; width:${width}; height: ${height}; overflow: hidden;">
-                ${appBootstrapContaineriFrame({ id, src, createOptions, className })}
+                ${appBootstrapContaineriFrame({ id: idRaw, src: srcRaw, createOptions, className: classNameRaw })}
             </div>
             <footer class="aui-dialog2-footer">
                 <div class="aui-dialog2-footer-actions">

--- a/spark-common/src/main/js/test/specs/sparkTemplatesSpec.js
+++ b/spark-common/src/main/js/test/specs/sparkTemplatesSpec.js
@@ -123,35 +123,6 @@ describe('SPARK templates', function() {
 
     });
 
-    describe('errorDialog', function() {
-        it('valid arguments return a result', function() {
-
-            var result = sparkTemplates.errorDialog({
-                'title': 'test-title',
-                'className': 'test-class-name'
-            });
-
-            expect(result).toBeDefined();
-
-        });
-
-        it('creates expected basic html structure', function() {
-
-            var resEl = $(sparkTemplates.errorDialog({
-                'title': 'test-title',
-                'className': 'test-class-name'
-            }));
-
-            expect(resEl.hasClass('dialog-components')).toBeTruthy();
-            expect(resEl.hasClass('test-class-name')).toBeTruthy();
-
-            expect(resEl.find('h2').length).toEqual(1);
-            expect(resEl.find('h2').text()).toEqual('test-title');
-
-        });
-
-    });
-
     describe('errorDialog2', function() {
         it('valid arguments return a result', function() {
 


### PR DESCRIPTION
Add simple escaping of the arguments that are directly concatenated to HTML, should enough for SPARK (adding a real templating library would probably be too much for the use case)

Also removed fallback for AUI Dialog 1, every still relevant version should support Dialog 2 now