### PR TITLE
DEV-109: Use require for loading AJS / jQuery only if globals not available

### DIFF
--- a/spark-common/src/main/js/webpack.config.js
+++ b/spark-common/src/main/js/webpack.config.js
@@ -54,8 +54,8 @@ module.exports = [
             path: distDir
         },
         externals: {
-            jquery: "window.require('jquery')",
-            ajs: "window.require('ajs')"
+            jquery: "(window.AJS && window.AJS.$) || window.require('jquery')",
+            ajs: "window.AJS || window.require('ajs')"
         }
     }),
     Object.assign({}, baseConfig, {


### PR DESCRIPTION
The change is needed because window.require('ajs') does not work on Jira, at least not yet.

On Confluence too the main motivation for using AMD module loading was that it has been announced
that the globals will be deprecated / removed: There should be no harm in actually using the
globals if they are still defined on Confluence either.