### PR TITLE
Dev 115 remove xwork class access

### DIFF
--- a/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppAction.java
+++ b/spark-jira/src/main/java/com/k15t/spark/jira/JiraAppAction.java
@@ -12,7 +12,6 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webwork.action.ServletActionContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -142,8 +141,7 @@ public class JiraAppAction extends JiraWebActionSupport {
                     + "<meta name=\"spark.app-base-url\" content=\"/plugins/servlet/hello-world/\">.");
         }
 
-        return ServletActionContext.getRequest().getContextPath() + "/" +
-                StringUtils.removeStart(baseElement.attr("content"), "/");
+        return super.insertContextPath("/" + StringUtils.removeStart(baseElement.attr("content"), "/"));
     }
 
 


### PR DESCRIPTION
* Inject configuration parameters via interceptor rather than using classes from the com.opensymphony package to retrieve them.
    * The com.opensymphony package is no longer available in Confluence 8 and the replacement package is not available in Confluence 7. By relying on interceptors we can drop all code relying on these packages.
    * The cache timestamp is now taken from the spring ApplicationContext similar to how the AtlassianAppServlet already does it.
* Use method from super class to add context path to URL rather than retrieving it ourselves.