### PR TITLE
DEV-114: API cleanup and velocity rendering removal in AppServlet and subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 * Removed classes that were intended for non-iframe SPAs.
 * The dropped `MessageBundleProvider` feature should be replaced by bundling i18n data in the JS bundle at build time.
 * Removed deprecated APIs
+* Renamed `AppServlet.prepareIndexHtml` to `customizeHtml` because it can now be invoked for HTML files with other names.
+    * `AppServlet.shouldCustomizeHtml` can be overridden in subclasses to control invocation of `customizeHtml`.
+    * For backwards compatibility the default implementation of `shouldCustomizeHtml` returns true when requesting `index.html`. 
+* Removed `AppServlet.renderVelocity` and `AtlassianAppServlet.getVelocityContext`
+    * If still required subclasses can implement it themselves by overriding `customizeHtml` (and `shouldCustomizeHtml`) accordingly.
+    * Also removed dependency on `atlassian-template-renderer-api` maven dependency.
 
 ## Xwork action declaration changes
 Spark 2.x used Xwork specific APIs to retrieve the default action configuration (SPA base url, web resources, selected web item). For compatibility with Confluence 8 this approach could no longer be used.

--- a/pom.xml
+++ b/pom.xml
@@ -96,18 +96,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>com.atlassian.templaterenderer</groupId>
-                <artifactId>atlassian-template-renderer-api</artifactId>
-                <version>2.0.0</version>
-                <scope>provided</scope>
-                <exclusions>
-                    <exclusion>
-                        <groupId>*</groupId>
-                        <artifactId>*</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <version>4.1.6.RELEASE</version>

--- a/spark-common/pom.xml
+++ b/spark-common/pom.xml
@@ -29,10 +29,6 @@
             <artifactId>sal-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.atlassian.templaterenderer</groupId>
-            <artifactId>atlassian-template-renderer-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>

--- a/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianAppServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianAppServlet.java
@@ -6,7 +6,6 @@ import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.message.LocaleResolver;
 import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.sal.api.user.UserProfile;
-import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.base.AppServlet;
 import com.k15t.spark.base.RequestProperties;
 import com.k15t.spark.base.util.DocumentOutputUtil;
@@ -19,9 +18,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 
 
@@ -29,18 +26,16 @@ public abstract class AtlassianAppServlet extends AppServlet {
 
     private final LoginUriProvider loginUriProvider;
     private final UserManager userManager;
-    private final TemplateRenderer templateRenderer;
     private final LocaleResolver localeResolver;
     private final ApplicationProperties applicationProperties;
     private final long pluginModifiedTimestamp;
 
 
-    protected AtlassianAppServlet(LoginUriProvider loginUriProvider, UserManager userManager, TemplateRenderer templateRenderer,
-            LocaleResolver localeResolver, ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
+    protected AtlassianAppServlet(LoginUriProvider loginUriProvider, UserManager userManager, LocaleResolver localeResolver,
+            ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
 
         this.loginUriProvider = Objects.requireNonNull(loginUriProvider);
         this.userManager = Objects.requireNonNull(userManager);
-        this.templateRenderer = Objects.requireNonNull(templateRenderer);
         this.localeResolver = Objects.requireNonNull(localeResolver);
         this.applicationProperties = Objects.requireNonNull(applicationProperties);
 
@@ -61,14 +56,7 @@ public abstract class AtlassianAppServlet extends AppServlet {
 
 
     @Override
-    protected String renderVelocity(String template, RequestProperties props) throws IOException {
-        Map<String, Object> context = getVelocityContext(props.getRequest());
-        return templateRenderer.renderFragment(template, context);
-    }
-
-
-    @Override
-    protected String prepareIndexHtml(String indexHtml, RequestProperties props) throws IOException {
+    protected String customizeHtml(String indexHtml, RequestProperties props) throws IOException {
         if (!isDevMode()) {
             Document document = Jsoup.parse(indexHtml, props.getUri().toString());
             applyCacheKeysToResourceUrls(document, props);
@@ -83,15 +71,6 @@ public abstract class AtlassianAppServlet extends AppServlet {
     protected void applyCacheKeysToResourceUrls(Document document, RequestProperties props) {
         Locale locale = localeResolver.getLocale(props.getRequest());
         DocumentOutputUtil.applyCacheKeysToResourceUrls(document, pluginModifiedTimestamp, locale);
-    }
-
-
-    /**
-     * Override this method to provide parameters to the Velocity context that
-     * is used to render the HTML file.
-     */
-    protected Map<String, Object> getVelocityContext(HttpServletRequest ignored) {
-        return Collections.emptyMap();
     }
 
 

--- a/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeContentServlet.java
+++ b/spark-common/src/main/java/com/k15t/spark/atlassian/AtlassianIframeContentServlet.java
@@ -4,7 +4,6 @@ import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.message.LocaleResolver;
 import com.atlassian.sal.api.user.UserManager;
-import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.base.RequestProperties;
 import com.k15t.spark.base.util.DocumentOutputUtil;
 import org.jsoup.Jsoup;
@@ -21,12 +20,10 @@ import java.io.IOException;
  */
 public abstract class AtlassianIframeContentServlet extends AtlassianAppServlet {
 
-    protected AtlassianIframeContentServlet(LoginUriProvider loginUriProvider,
-            UserManager userManager, TemplateRenderer templateRenderer,
-            LocaleResolver localeResolver, ApplicationProperties applicationProperties,
-            ApplicationContext applicationContext) {
+    protected AtlassianIframeContentServlet(LoginUriProvider loginUriProvider, UserManager userManager, LocaleResolver localeResolver,
+            ApplicationProperties applicationProperties, ApplicationContext applicationContext) {
 
-        super(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties, applicationContext);
+        super(loginUriProvider, userManager, localeResolver, applicationProperties, applicationContext);
     }
 
     // AtlassianAppServlet handles some heavy lifting required for living in the plugin servlet environment
@@ -34,7 +31,7 @@ public abstract class AtlassianIframeContentServlet extends AtlassianAppServlet 
 
 
     @Override
-    protected String prepareIndexHtml(String indexHtml, RequestProperties props) throws IOException {
+    protected String customizeHtml(String indexHtml, RequestProperties props) throws IOException {
         Document document = Jsoup.parse(indexHtml, props.getUri().toString());
 
         if (!isDevMode()) {

--- a/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
+++ b/spark-common/src/main/js/src_contentwin/spark-contentwindow.js
@@ -6,7 +6,7 @@ window.SPARK = window.SPARK || {};
 
     // windowEl.frameElement would be null if domains are not same but
     // same domain is prereq for SPARK usage
-    var parentSpark = windowEl.frameElement.SPARK;
+    var parentSpark = windowEl.frameElement.SPARK || {};
 
     var getContextData = function() {
         return parentSpark.contextData;

--- a/spark-common/src/test/java/com/k15t/spark/atlassian/AtlassianIframeAppServletTest.java
+++ b/spark-common/src/test/java/com/k15t/spark/atlassian/AtlassianIframeAppServletTest.java
@@ -4,7 +4,6 @@ import com.atlassian.sal.api.ApplicationProperties;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.message.LocaleResolver;
 import com.atlassian.sal.api.user.UserManager;
-import com.atlassian.templaterenderer.TemplateRenderer;
 import com.k15t.spark.base.RequestProperties;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -36,7 +35,6 @@ public class AtlassianIframeAppServletTest {
     private static ServletConfig servletConfig;
     private LoginUriProvider loginUriProvider;
     private UserManager userManager;
-    private TemplateRenderer templateRenderer;
     private LocaleResolver localeResolver;
     private ApplicationProperties applicationProperties;
     private ApplicationContext applicationContext;
@@ -56,14 +54,13 @@ public class AtlassianIframeAppServletTest {
 
         loginUriProvider = Mockito.mock(LoginUriProvider.class);
         userManager = Mockito.mock(UserManager.class);
-        templateRenderer = Mockito.mock(TemplateRenderer.class);
         localeResolver = Mockito.mock(LocaleResolver.class);
         applicationProperties = Mockito.mock(ApplicationProperties.class);
         applicationContext = Mockito.mock(ApplicationContext.class);
         Mockito.when(applicationContext.getStartupDate()).thenReturn(new Date().getTime() - 1000);
 
         testInstance = Mockito.spy(
-                new AtlassianIframeContentServlet(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties,
+                new AtlassianIframeContentServlet(loginUriProvider, userManager, localeResolver, applicationProperties,
                         applicationContext) {
                     @Override
                     protected boolean isDevMode() {
@@ -78,7 +75,7 @@ public class AtlassianIframeAppServletTest {
     @Test
     public void servesIframeContent() throws Exception {
 
-        String prepIndexRes = testInstance.prepareIndexHtml(
+        String prepIndexRes = testInstance.customizeHtml(
                 "<html><head><script src='test.js'/></head><body><p id='body-el'>test</p></body></html>",
                 props);
 
@@ -116,7 +113,7 @@ public class AtlassianIframeAppServletTest {
         String testHtml = "<html><head><script src='test.js'/></head><body><p id='body-el'>test</p></body></html>";
 
         AtlassianIframeContentServlet customizingInstance = Mockito.spy(
-                new AtlassianIframeContentServlet(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties,
+                new AtlassianIframeContentServlet(loginUriProvider, userManager, localeResolver, applicationProperties,
                         applicationContext) {
                     @Override
                     protected boolean isDevMode() {
@@ -131,7 +128,7 @@ public class AtlassianIframeAppServletTest {
                 });
         Mockito.when(customizingInstance.getServletConfig()).thenReturn(servletConfig);
 
-        String resStr = customizingInstance.prepareIndexHtml(testHtml, props);
+        String resStr = customizingInstance.customizeHtml(testHtml, props);
 
         Document resDoc = Jsoup.parse(resStr);
 
@@ -153,7 +150,7 @@ public class AtlassianIframeAppServletTest {
     public void requestHandlingIsStoppedOnPermissionProblem() throws Exception {
 
         AtlassianIframeContentServlet permissionVerifyingInstance =
-                new AtlassianIframeContentServlet(loginUriProvider, userManager, templateRenderer, localeResolver, applicationProperties,
+                new AtlassianIframeContentServlet(loginUriProvider, userManager, localeResolver, applicationProperties,
                         applicationContext) {
                     @Override
                     protected boolean isDevMode() {


### PR DESCRIPTION
* Renamed `AppServlet.prepareIndexHtml` to `customizeHtml` because it can now be invoked for HTML files with other names. 
    * `AppServlet.shouldCustomizeHtml` can be overridden in subclasses to control invocation of `customizeHtml`.
    * For backwards compatibility the default implementation of `shouldCustomizeHtml` returns true when requesting `index.html`.
* Removed `AppServlet.renderVelocity` and `AtlassianAppServlet.getVelocityContext`
    * If still required subclasses can implement it themselves by overriding `customizeHtml` (and `shouldCustomizeHtml`) accordingly.
    * Also removed dependency on `atlassian-template-renderer-api` maven dependency.