### PR TITLE
Set protected methods accessible to invoke through reflection

### DIFF
--- a/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSparkActionHelper.java
+++ b/spark-confluence/src/main/java/com/k15t/spark/confluence/ConfluenceIframeSparkActionHelper.java
@@ -35,6 +35,7 @@ public class ConfluenceIframeSparkActionHelper {
         try {
             @SuppressWarnings({"JavaReflectionMemberAccess", "RedundantSuppression"})
             Method getActiveRequest = ConfluenceActionSupport.class.getDeclaredMethod("getActiveRequest");
+            getActiveRequest.setAccessible(true);
             HttpServletRequest request = (HttpServletRequest) getActiveRequest.invoke(action);
             return request != null ? request.getQueryString() : null;
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
@@ -44,6 +45,7 @@ public class ConfluenceIframeSparkActionHelper {
         try {
             @SuppressWarnings({"JavaReflectionMemberAccess", "RedundantSuppression"})
             Method getCurrentRequest = ConfluenceActionSupport.class.getDeclaredMethod("getCurrentRequest");
+            getCurrentRequest.setAccessible(true);
             Object javaxRequest = getCurrentRequest.invoke(action);
             if (javaxRequest == null) {
                 return null;


### PR DESCRIPTION
Both
- ConfluenceActionSupport#getCurrentRequest (Confluence 8/9)
- ConfluenceActionSupport#getActiveRequest (Confluence 10)
are protected.

We need to setAccessible(true) to invoke them through reflection.